### PR TITLE
param response verification

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,7 +66,7 @@ Ready to contribute? Here's how to set up ``htheatpump`` for local development.
 3. Install your local copy into a virtualenv [1]_. Assuming you have ``virtualenvwrapper`` installed, this is how you
    set up your fork for local development under Python 3.5::
 
-    $ mkvirtualenv hthp-py35 -p python3.5
+    $ mkvirtualenv hthp-py35 -p $(which python3.5)
     $ cd htheatpump/
     $ python setup.py develop
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,12 +5,17 @@ History
 ------------------
 
 * added some more heat pump parameters (data points) in ``htparams.csv``
-* extended sample script ``htfaultlist.py`` by the possibility to write JSON/CSV file
+* extended sample script ``htfaultlist.py`` by the possibility to write a JSON/CSV file
 * added new sample script ``hthttp.py``
 * fixed some formatting (flake8) errors
 * some improvement for the reconnect in the ``login()`` function of ``HtHeatpump``
 * changed return type of ``HtHeatpump.get_fault_list()`` from ``dict`` to ``list``
 * added support for Python 3.6
+* added support for a user specific parameter definition file under ``~/.htheatpump/htparams.csv``
+* extended sample ``htbackup.py`` to store also MIN and MAX definitions of each data point
+* added method to verify the parameter definitions in ``htparams.csv`` during a ``get_param()`` or ``set_param()``;
+  this is just for safety to be sure that the parameter definitions in ``HtParams`` are correct and no wrong
+  parameter will be changed (can be disabled by setting the property ``HtHeatpump.verify_param`` to ``False``)
 
 1.0.0 (2018-01-12)
 ------------------

--- a/docs/htscripts.rst
+++ b/docs/htscripts.rst
@@ -143,16 +143,16 @@ Source: https://github.com/dstrigl/htheatpump/blob/master/samples/htbackup.py
 
 **Example:**
 
-.. code-block:: shell  TODO
+.. code-block:: shell
 
     $ python3 htbackup.py --baudrate 9600 --csv backup.csv
-    'SP,NR=0' [Language]: 0
-    'SP,NR=1' [TBF_BIT]: 0
-    'SP,NR=2' [Rueckruferlaubnis]: 1
+    'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
+    'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
+    'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
     ...
-    'MP,NR=0' [Temp. Aussen]: 0.1
-    'MP,NR=1' [Temp. Aussen verzoegert]: 0.1
-    'MP,NR=2' [Temp. Brauchwasser]: 50.2
+    'MP,NR=0' [Temp. Aussen]: VAL='-7.0', MIN='-20.0', MAX='40.0'
+    'MP,NR=1' [Temp. Aussen verzoegert]: VAL='-6.9', MIN='-20.0', MAX='40.0'
+    'MP,NR=2' [Temp. Brauchwasser]: VAL='45.7', MIN='0.0', MAX='70.0'
     ...
 
 

--- a/docs/htscripts.rst
+++ b/docs/htscripts.rst
@@ -143,7 +143,7 @@ Source: https://github.com/dstrigl/htheatpump/blob/master/samples/htbackup.py
 
 **Example:**
 
-.. code-block:: shell
+.. code-block:: shell  TODO
 
     $ python3 htbackup.py --baudrate 9600 --csv backup.csv
     'SP,NR=0' [Language]: 0

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,6 +3,9 @@
 Installation
 ============
 
+For both installation methods described in the following sections the usage of Python virtual environments [1]_
+is highly recommended.
+
 
 Stable release
 --------------
@@ -48,3 +51,7 @@ Once you have a copy of the source, you can install it with:
 
 .. _Github repo: https://github.com/dstrigl/htheatpump
 .. _tarball: https://github.com/dstrigl/htheatpump/tarball/master
+
+
+.. [1] If you need more information about Python virtual environments take a look at this
+       `article on RealPython <https://realpython.com/blog/python/python-virtual-environments-a-primer/>`_.

--- a/htheatpump/htheatpump.py
+++ b/htheatpump/htheatpump.py
@@ -760,7 +760,7 @@ class HtHeatpump:
             m = re.match(r"^{},.*NAME=([^,]+).*VAL=([^,]+).*$".format(param.cmd()), resp)
             if not m:
                 raise IOError("invalid response for query of parameter {!r} [{}]".format(name, resp))
-            # to be more safe check if the parameter name matches with its definition (e.g. "NAME=Temp. Aussen")
+            # to be more safe check if the returned parameter name matches with its definition (e.g. "Temp. Aussen")
             resp_name = m.group(1).strip()
             if resp_name != name:
                 if self._verify_param_name:
@@ -810,7 +810,7 @@ class HtHeatpump:
         if name not in HtParams:
             raise KeyError("parameter definition for parameter {!r} not found".format(name))
         # verify the parameter name before changing any value (if desired) by calling 'get_param(...)'
-        #   (this is just for safety, so that no wrong parameter will be changed)
+        #   (this is just for safety, so that no wrong parameter will be changed!)
         if self._verify_param_name:
             self.get_param(name)
         param = HtParams[name]
@@ -824,7 +824,7 @@ class HtHeatpump:
             m = re.match(r"^{},.*NAME=([^,]+).*VAL=([^,]+).*$".format(param.cmd()), resp)
             if not m:
                 raise IOError("invalid response for set parameter {!r} to {!r} [{}]".format(name, val, resp))
-            # to be more safe check if the parameter name matches with its definition (e.g. "NAME=HKR Soll_Raum")
+            # to be more safe check if the returned parameter name matches with its definition (e.g. "HKR Soll_Raum")
             resp_name = m.group(1).strip()
             if resp_name != name:
                 if self._verify_param_name:

--- a/htheatpump/htheatpump.py
+++ b/htheatpump/htheatpump.py
@@ -219,7 +219,7 @@ class HtHeatpump:
         self._ser_settings = { 'device': device }
         self._ser_settings.update(kwargs)
         self._ser = None
-        self._verify_param_name = True
+        self._verify_param = True
 
     def __del__(self):
         # close the connection if still established
@@ -287,19 +287,20 @@ class HtHeatpump:
         return self._ser and self._ser.is_open
 
     @property
-    def verify_param_name(self):
-        """ Property to get or set whether the parameter name verification during a :class:`get_param`
-        or :class:`set_param` should be active or not.
+    def verify_param(self):
+        """ Property to get or set whether the parameter verification (of *name*, *min* and *max*) during
+        a :class:`get_param` or :class:`set_param` should be active or not. This is just for safety
+        to be sure that the parameter definitions in ``HtParams`` are correct!
 
         :param: Boolean value which indicates whether the verification should be active or not.
         :returns: :const:`True` if the verification is active, :const:`False` otherwise.
         :rtype: ``bool``
         """
-        return self._verify_param_name
+        return self._verify_param
 
-    @verify_param_name.setter
-    def verify_param_name(self, val):
-        self._verify_param_name = val
+    @verify_param.setter
+    def verify_param(self, val):
+        self._verify_param = val
 
     def send_request(self, cmd):
         """ Sends a request to the heat pump.
@@ -721,6 +722,46 @@ class HtHeatpump:
             _logger.error("query for fault list failed: {!s}".format(e))
             raise
 
+    def _verify_param_resp(self, name, param, resp):
+        """ Perform a verification of the parameter response string and return the extracted parameter value.
+        It checks whether the name, min and max value matches with the parameter definition in ``HtParams``.
+
+        :param name: The parameter name, e.g. :data:`"Betriebsart"`.
+        :type name: str
+        :param param: The corresponding parameter definition.
+        :type param: htparams.HtParam
+        :param resp: The received response string of the heat pump.
+        :type resp: str
+
+        :returns: Returned value of the parameter.
+        :rtype: ``str``, ``bool``, ``int`` or ``float``
+        """
+        # search for pattern "NAME=...", "VAL=...", "MAX=..." and "MIN=..." inside the response string
+        m = re.match(r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(param.cmd()), resp)
+        if not m:
+            raise IOError("invalid response for access to parameter {!r} [{}]".format(name, resp))
+        try:
+            # verify 'NAME'
+            resp_name = m.group(1).strip()
+            if resp_name != name:
+                raise IOError("parameter name doesn't match with {!r} [{}]".format(name, resp_name))
+            # verify 'MAX'
+            resp_max = param.from_str(m.group(3).strip())
+            if resp_max != param.max:
+                raise IOError("parameter max value doesn't match with {!r} [{}]".format(param.max, resp_max))
+            # verify 'MIN'
+            resp_min = param.from_str(m.group(4).strip())
+            if resp_min != param.min:
+                raise IOError("parameter min value doesn't match with {!r} [{}]".format(param.min, resp_min))
+        except Exception as e:
+            if self._verify_param:
+                raise
+            else:
+                _logger.warning("response verification of param {!r}: {!s}".format(name, e))
+        # convert the returned value (string) to the expected data type (defined in HtParams)
+        val = param.from_str(m.group(2).strip())
+        return val
+
     def get_param(self, name):
         """ Query for a specific parameter of the heat pump.
 
@@ -743,10 +784,6 @@ class HtHeatpump:
 
         will return the current measured outdoor temperature in °C.
         """
-        #
-        # TODO: check received value against limits (min, max) in 'htparams.csv'
-        #           (and write a warning to the log if it doesn't match)
-        #
         # find the corresponding definition for the requested parameter
         if name not in HtParams:
             raise KeyError("parameter definition for parameter {!r} not found".format(name))
@@ -756,20 +793,7 @@ class HtHeatpump:
         # ... and wait for the response
         try:
             resp = self.read_response()
-            # search for pattern "VAL=..." inside the response string
-            m = re.match(r"^{},.*NAME=([^,]+).*VAL=([^,]+).*$".format(param.cmd()), resp)
-            if not m:
-                raise IOError("invalid response for query of parameter {!r} [{}]".format(name, resp))
-            # to be more safe check if the returned parameter name matches with its definition (e.g. "Temp. Aussen")
-            resp_name = m.group(1).strip()
-            if resp_name != name:
-                if self._verify_param_name:
-                    raise IOError("parameter name doesn't match {!r} [{}]".format(name, resp_name))
-                else:
-                    _logger.warning("get_param({!r}): parameter name doesn't match [{}]".format(name, resp_name))
-            val = m.group(2).strip()
-            # convert the returned value (string) to the expected data type
-            val = param.from_str(val)
+            val = self._verify_param_resp(name, param, resp)
             _logger.debug("{!r} = {!s}".format(name, val))
             return val
         except Exception as e:
@@ -802,16 +826,12 @@ class HtHeatpump:
 
         will set the desired room temperature of the heating circuit to 21.5 °C.
         """
-        #
-        # TODO: check write access right of the parameter; see 'HtParam.acl'
-        # TODO: check passed value against defined limits (min, max) in 'htparams.csv'
-        #
         # find the corresponding definition for the requested parameter
         if name not in HtParams:
             raise KeyError("parameter definition for parameter {!r} not found".format(name))
-        # verify the parameter name before changing any value (if desired) by calling 'get_param(...)'
-        #   (this is just for safety, so that no wrong parameter will be changed!)
-        if self._verify_param_name:
+        # verify the parameter definition before changing any value (if desired) by calling 'get_param(...)'
+        #   (this is just for safety to be sure that the parameter definitions in HtParams are correct!)
+        if self._verify_param:
             self.get_param(name)
         param = HtParams[name]
         # send command to the heat pump
@@ -820,20 +840,7 @@ class HtHeatpump:
         # ... and wait for the response
         try:
             resp = self.read_response()
-            # search for pattern "VAL=..." inside the response string
-            m = re.match(r"^{},.*NAME=([^,]+).*VAL=([^,]+).*$".format(param.cmd()), resp)
-            if not m:
-                raise IOError("invalid response for set parameter {!r} to {!r} [{}]".format(name, val, resp))
-            # to be more safe check if the returned parameter name matches with its definition (e.g. "HKR Soll_Raum")
-            resp_name = m.group(1).strip()
-            if resp_name != name:
-                if self._verify_param_name:
-                    raise IOError("parameter name doesn't match {!r} [{}]".format(name, resp_name))
-                else:
-                    _logger.warning("set_param({!r}): parameter name doesn't match [{}]".format(name, resp_name))
-            val = m.group(2).strip()
-            # convert the returned value (string) to the expected data type
-            val = param.from_str(val)
+            val = self._verify_param_resp(name, param, resp)
             _logger.debug("{!r} = {!s}".format(name, val))
             return val
         except Exception as e:

--- a/htheatpump/htheatpump.py
+++ b/htheatpump/htheatpump.py
@@ -723,7 +723,7 @@ class HtHeatpump:
             raise
 
     def _verify_param_resp(self, name, param, resp):
-        """ Perform a verification of the parameter response string and return the extracted parameter value.
+        """ Perform a verification of the parameter access response string and return the extracted parameter value.
         It checks whether the name, min and max value matches with the parameter definition in ``HtParams``.
 
         :param name: The parameter name, e.g. :data:`"Betriebsart"`.
@@ -739,7 +739,7 @@ class HtHeatpump:
         # search for pattern "NAME=...", "VAL=...", "MAX=..." and "MIN=..." inside the response string
         m = re.match(r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(param.cmd()), resp)
         if not m:
-            raise IOError("invalid response for access to parameter {!r} [{}]".format(name, resp))
+            raise IOError("invalid response for access of parameter {!r} [{}]".format(name, resp))
         try:
             # verify 'NAME'
             resp_name = m.group(1).strip()
@@ -754,11 +754,11 @@ class HtHeatpump:
             if resp_min != param.min:
                 raise IOError("parameter min value doesn't match with {!r} [{}]".format(param.min, resp_min))
         except Exception as e:
-            if self._verify_param:
+            if self._verify_param:  # interpret as error?
                 raise
-            else:
+            else:  # or only as a warning?
                 _logger.warning("response verification of param {!r}: {!s}".format(name, e))
-        # convert the returned value (string) to the expected data type (defined in HtParams)
+        # convert the returned value (string) to the expected data type (as defined in HtParams)
         val = param.from_str(m.group(2).strip())
         return val
 

--- a/htheatpump/htparams.py
+++ b/htheatpump/htparams.py
@@ -277,11 +277,9 @@ class HtParams(Singleton, metaclass=HtParamsMeta):
                           param.data_type if param.data_type else "<unknown>",
                           param.min, param.max))
 
-    def _load_from_csv(filename):
-        """ Load all supported heat pump parameter definitions from the passed CSV file.
+    def _load_from_csv():
+        """ Load all supported heat pump parameter definitions from the CSV file.
 
-        :param filename: Name of the CSV file with the parameter definitions.
-        :type filename: str
         :returns: Dictionary of the supported heat pump parameters:
             ::
 
@@ -293,6 +291,11 @@ class HtParams(Singleton, metaclass=HtParamsMeta):
 
         :rtype: ``dict``
         """
+        # search for a user defined parameter CSV file in "~/.htheatpump/..."
+        filename = path.expanduser(path.join("~/.htheatpump", CSV_FILE))
+        if not path.exists(filename):
+            # ... and switch back to the default one if no one was found
+            filename = path.join(path.dirname(path.abspath(__file__)), CSV_FILE)
         params = {}
         with open(filename) as f:
             reader = csv.reader(f, delimiter=',', skipinitialspace=True)
@@ -316,7 +319,7 @@ class HtParams(Singleton, metaclass=HtParamsMeta):
         return params
 
     # Dictionary of the supported Heliotherm heat pump parameters
-    _params = _load_from_csv(path.join(path.dirname(path.abspath(__file__)), CSV_FILE))
+    _params = _load_from_csv()
 
 
 # --------------------------------------------------------------------------------------------- #

--- a/htheatpump/htparams.py
+++ b/htheatpump/htparams.py
@@ -291,7 +291,7 @@ class HtParams(Singleton, metaclass=HtParamsMeta):
 
         :rtype: ``dict``
         """
-        # search for a user defined parameter CSV file in "~/.htheatpump/..."
+        # search for a user defined parameter CSV file in "~/.htheatpump"
         filename = path.expanduser(path.join("~/.htheatpump", CSV_FILE))
         if not path.exists(filename):
             # ... and switch back to the default one if no one was found

--- a/htheatpump/htparams.py
+++ b/htheatpump/htparams.py
@@ -296,6 +296,7 @@ class HtParams(Singleton, metaclass=HtParamsMeta):
         if not path.exists(filename):
             # ... and switch back to the default one if no one was found
             filename = path.join(path.dirname(path.abspath(__file__)), CSV_FILE)
+        print("htheatpump: load parameter definitions from: {}".format(filename))
         params = {}
         with open(filename) as f:
             reader = csv.reader(f, delimiter=',', skipinitialspace=True)

--- a/htheatpump/htparams.py
+++ b/htheatpump/htparams.py
@@ -252,6 +252,12 @@ class HtParamsMeta(type):
 class HtParams(Singleton, metaclass=HtParamsMeta):
     """ Dictionary of the supported Heliotherm heat pump parameters. [*]_
 
+    .. note::
+
+        The supported parameters and their definitions are loaded from the CSV file
+        ``htparams.csv`` in this package, but the user can create his own user specific
+        CSV file under ``~/.htheatpump/htparams.csv``.
+
     .. [*] Most of the supported heat pump parameters were found by "sniffing" the
            serial communication of the Heliotherm home control Windows application
            (http://homecontrol.heliotherm.com) during a refresh! ;-)

--- a/samples/htbackup.py
+++ b/samples/htbackup.py
@@ -115,7 +115,7 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.WARNING)
 
     hp = HtHeatpump(args.device, baudrate=args.baudrate)
     start = timer()
@@ -146,7 +146,7 @@ def main():
                     m = re.match(r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(data_point), resp)
                     if not m:
                         raise IOError("invalid response for query of data point {!r} [{}]".format(data_point, resp))
-                    name, value, max, min = m.group(1, 4)  # extract name and value
+                    name, value, max, min = m.group(1, 2, 3, 4)  # extract name, value, max and min
                     print("{!r} [{}]: VAL={}, MIN={}, MAX={}".format(data_point, name, value, min, max))
                     # store the determined data in the result dict
                     result[dp_type].update({i: {"name": name, "value": value, "min": min, "max": max}})

--- a/samples/htbackup.py
+++ b/samples/htbackup.py
@@ -21,16 +21,16 @@
 
     Example:
 
-    .. code-block:: shell  TODO
+    .. code-block:: shell
 
        $ python3 htbackup.py --baudrate 9600 --csv backup.csv
-       'SP,NR=0' [Language]: 0
-       'SP,NR=1' [TBF_BIT]: 0
-       'SP,NR=2' [Rueckruferlaubnis]: 1
+       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
+       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
+       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
        ...
-       'MP,NR=0' [Temp. Aussen]: 0.1
-       'MP,NR=1' [Temp. Aussen verzoegert]: 0.1
-       'MP,NR=2' [Temp. Brauchwasser]: 50.2
+       'MP,NR=0' [Temp. Aussen]: VAL='-7.0', MIN='-20.0', MAX='40.0'
+       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='-6.9', MIN='-20.0', MAX='40.0'
+       'MP,NR=2' [Temp. Brauchwasser]: VAL='45.7', MIN='0.0', MAX='70.0'
        ...
 """
 
@@ -52,12 +52,12 @@ def main():
         description = textwrap.dedent('''\
             Command line tool to create a backup of the Heliotherm heat pump data points.
 
-            Example:  TODO
+            Example:
 
               $ python3 %(prog)s --baudrate 9600 --csv backup.csv
-              'SP,NR=0' [Language]: 0
-              'SP,NR=1' [TBF_BIT]: 0
-              'SP,NR=2' [Rueckruferlaubnis]: 1
+              'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
+              'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
+              'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
               ...
             '''),
         formatter_class = argparse.RawDescriptionHelpFormatter,

--- a/samples/htbackup.py
+++ b/samples/htbackup.py
@@ -21,7 +21,7 @@
 
     Example:
 
-    .. code-block:: shell
+    .. code-block:: shell  TODO
 
        $ python3 htbackup.py --baudrate 9600 --csv backup.csv
        'SP,NR=0' [Language]: 0
@@ -50,9 +50,9 @@ _logger = logging.getLogger(__name__)
 def main():
     parser = argparse.ArgumentParser(
         description = textwrap.dedent('''\
-            Command line tool to create a backup of the Heliotherm heat pump settings.
+            Command line tool to create a backup of the Heliotherm heat pump data points.
 
-            Example:
+            Example:  TODO
 
               $ python3 %(prog)s --baudrate 9600 --csv backup.csv
               'SP,NR=0' [Language]: 0
@@ -109,6 +109,11 @@ def main():
         action = "store_true",
         help = "increase output verbosity by activating logging")
 
+    parser.add_argument(
+        "--without-values",
+        action = "store_true",
+        help = "store heat pump data points without their current value (keep it blank)")
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -147,7 +152,9 @@ def main():
                     if not m:
                         raise IOError("invalid response for query of data point {!r} [{}]".format(data_point, resp))
                     name, value, max, min = m.group(1, 2, 3, 4)  # extract name, value, max and min
-                    print("{!r} [{}]: VAL={}, MIN={}, MAX={}".format(data_point, name, value, min, max))
+                    if args.without_values:
+                        value = ""  # keep it blank (if desired)
+                    print("{!r} [{}]: VAL={!r}, MIN={!r}, MAX={!r}".format(data_point, name, value, min, max))
                     # store the determined data in the result dict
                     result[dp_type].update({i: {"name": name, "value": value, "min": min, "max": max}})
                 except Exception as e:

--- a/samples/htdatetime.py
+++ b/samples/htdatetime.py
@@ -113,7 +113,7 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.WARNING)
 
     hp = HtHeatpump(args.device, baudrate=args.baudrate)
     start = timer()

--- a/samples/htfaultlist.py
+++ b/samples/htfaultlist.py
@@ -124,7 +124,7 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.WARNING)
 
     hp = HtHeatpump(args.device, baudrate=args.baudrate)
     start = timer()

--- a/samples/htquery.py
+++ b/samples/htquery.py
@@ -118,7 +118,7 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.WARNING)
     # if not given, query for all "known" parameters
     params = args.name if args.name else HtParams.keys()
 

--- a/samples/htset.py
+++ b/samples/htset.py
@@ -114,7 +114,7 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.WARNING)
 
     hp = HtHeatpump(args.device, baudrate=args.baudrate)
     start = timer()

--- a/samples/htshell.py
+++ b/samples/htshell.py
@@ -114,7 +114,7 @@ def main():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.WARNING)
 
     hp = HtHeatpump(args.device, baudrate=args.baudrate)
     start = timer()


### PR DESCRIPTION
* added support for a user specific parameter definition file under ``~/.htheatpump/htparams.csv``
* extended sample ``htbackup.py`` to store also MIN and MAX definitions of each data point
* added method to verify the parameter definitions in ``htparams.csv`` during a ``get_param()`` or ``set_param()``