### PR TITLE
Issue 369 - Removed log of loaded definition file path

### DIFF
--- a/htheatpump/htparams.py
+++ b/htheatpump/htparams.py
@@ -392,7 +392,6 @@ class HtParam:
 
 
 class HtParamsMeta(type):  # pragma: no cover
-      
     def __init__(cls, *args, **kwargs):
         cls._params = dict()
         cls._csv_file = ""

--- a/htheatpump/htparams.py
+++ b/htheatpump/htparams.py
@@ -392,6 +392,11 @@ class HtParam:
 
 
 class HtParamsMeta(type):  # pragma: no cover
+      
+    def __init__(cls, *args, **kwargs):
+        cls._params = dict()
+        cls._csv_file = ""
+
     def __contains__(cls, item):
         return item in cls._params
 

--- a/htheatpump/htparams.py
+++ b/htheatpump/htparams.py
@@ -391,26 +391,6 @@ class HtParam:
             return HtParam._to_str(self, arg)  # type: ignore
 
 
-class HtParamsMeta(type):  # pragma: no cover
-    def __init__(cls, *args, **kwargs):
-        cls._params = dict()
-        cls._csv_file = ""
-
-    def __contains__(cls, item):
-        return item in cls._params
-
-    def __getitem__(cls, key):
-        return cls._params[key]
-
-    def __len__(cls):
-        return len(cls._params)
-
-    @property
-    def definition_file(cls) -> str:
-        """Returns the path of the used parameter definition file."""
-        return cls._csv_file
-
-
 # ------------------------------------------------------------------------------------------------------------------- #
 # Parameter dictionary class
 # ------------------------------------------------------------------------------------------------------------------- #
@@ -483,6 +463,26 @@ def _load_params_from_csv() -> Tuple[Dict[str, HtParam], str]:
     return params, filename
 
 
+class HtParamsMeta(type):  # pragma: no cover
+    def __init__(cls, *args, **kwargs):
+        # Load the supported Heliotherm heat pump parameters
+        cls._params, cls._csv_file = _load_params_from_csv()
+
+    def __contains__(cls, item):
+        return item in cls._params
+
+    def __getitem__(cls, key):
+        return cls._params[key]
+
+    def __len__(cls):
+        return len(cls._params)
+
+    @property
+    def definition_file(cls) -> str:
+        """Returns the path of the used parameter definition file."""
+        return cls._csv_file
+
+
 class HtParams(Singleton, metaclass=HtParamsMeta):
     """Dictionary of the supported Heliotherm heat pump parameters. [*]_
 
@@ -538,9 +538,6 @@ class HtParams(Singleton, metaclass=HtParamsMeta):
                     param.max_val,
                 )
             )
-
-    # Dictionary of the supported Heliotherm heat pump parameters
-    _params, _csv_file = _load_params_from_csv()
 
 
 # ------------------------------------------------------------------------------------------------------------------- #

--- a/tests/test_htparams.py
+++ b/tests/test_htparams.py
@@ -375,6 +375,10 @@ class TestHtParams:
         assert HtParams.dump() is None
         # assert 0
 
+    def test_definition_file(self):
+        assert HtParams.definition_file
+        # assert 0
+
     @pytest.mark.run_if_connected
     @pytest.mark.usefixtures("reconnect")
     @pytest.mark.parametrize("name, param", HtParams.items())

--- a/tests/test_htparams_async.py
+++ b/tests/test_htparams_async.py
@@ -375,6 +375,10 @@ class TestHtParams:
         assert HtParams.dump() is None
         # assert 0
 
+    def test_definition_file(self):
+        assert HtParams.definition_file
+        # assert 0
+
     @pytest.mark.run_if_connected
     @pytest.mark.usefixtures("reconnect")
     @pytest.mark.parametrize("name, param", HtParams.items())


### PR DESCRIPTION
- Removed the log "HTHEATPUMP: load parameter definitions from ..." to get a clean JSON output in the sample scripts (e.g. htquery).
- Instead, stored path of used parameter definition file in property `HtParams.definition_file`.