### PR TITLE
Port TCP socket support from socket-connection branch

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+1.3.4 (2025-04-21)
+------------------
+* ported support for connecting to the heat pump serial port over a TCP socket
+
 1.3.3 (2023-??-??)
 ------------------
 

--- a/htheatpump/__version__.py
+++ b/htheatpump/__version__.py
@@ -19,4 +19,4 @@
 
 from typing import Final
 
-__version__: Final = "1.3.2"
+__version__: Final = "1.3.4"

--- a/htheatpump/aiohtheatpump.py
+++ b/htheatpump/aiohtheatpump.py
@@ -27,6 +27,8 @@ import datetime
 import logging
 import re
 from typing import Dict, Final, List, Optional, Set, Tuple, Union, cast
+import socket
+from urllib.parse import urlparse
 
 import aioserial
 import serial
@@ -83,6 +85,8 @@ _LOGGER: Final = logging.getLogger(__name__)
 class AioHtHeatpump(HtHeatpump):
     """Object which encapsulates the asynchronous communication with the Heliotherm heat pump.
 
+    :param url: The TCP URL (e.g., tcp://192.168.1.100:9999). Provide either device or url.
+    :type url: Optional[str]
     :param device: The serial device to attach to (e.g. :data:`/dev/ttyUSB0`).
     :type device: str
     :param baudrate: The baud rate to use for the serial device.
@@ -94,7 +98,7 @@ class AioHtHeatpump(HtHeatpump):
     :param stopbits: The number of stop bits to use.
     :type stopbits: float or int
     :param timeout: The read timeout value.
-        Default is :attr:`~htheatpump.htheatpump.HtHeatpump.DEFAULT_SERIAL_TIMEOUT`.
+        Default is :attr:`~htheatpump.htheatpump.HtHeatpump.DEFAULT_TIMEOUT`.
     :type timeout: None, float or int
     :param xonxoff: Software flow control enabled.
     :type xonxoff: bool
@@ -121,27 +125,36 @@ class AioHtHeatpump(HtHeatpump):
 
     Example::
 
-        hp = AioHtHeatpump("/dev/ttyUSB0", baudrate=9600)
-        try:
-            hp.open_connection()
-            await hp.login_async()
-            # query for the outdoor temperature
-            temp = await hp.get_param_async("Temp. Aussen")
-            print(temp)
-            # ...
-        finally:
-            await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-            hp.close_connection()
+        # Serial
+        hp = AioHtHeatpump(device="/dev/ttyUSB0", baudrate=9600)
+        # TCP
+        hp = AioHtHeatpump(url="tcp://192.168.1.100:9999")
+
+        async def run():
+            try:
+                # open_connection is synchronous (prepares settings)
+                hp.open_connection()
+                # login_async establishes connection and logs in
+                await hp.login_async()
+                temp = await hp.get_param_async("Temp. Aussen")
+                print(temp)
+                # ...
+            finally:
+                # logout_async also closes the connection
+                await hp.logout_async()
+
+        asyncio.run(run())
     """
 
     def __init__(
         self,
-        device: str,
+        device: Optional[str] = None, # Changed: Make optional
+        url: Optional[str] = None,    # Added: url parameter
         baudrate: int = 115200,
         bytesize: int = serial.EIGHTBITS,
         parity: str = serial.PARITY_NONE,
         stopbits: Union[float, int] = serial.STOPBITS_ONE,
-        timeout: Optional[Union[float, int]] = HtHeatpump.DEFAULT_SERIAL_TIMEOUT,
+        timeout: Optional[Union[float, int]] = HtHeatpump.DEFAULT_TIMEOUT,
         xonxoff: bool = True,
         rtscts: bool = False,
         write_timeout: Optional[Union[float, int]] = None,
@@ -157,6 +170,7 @@ class AioHtHeatpump(HtHeatpump):
         """Initialize the AioHtHeatpump class."""
 
         super().__init__(
+            url,
             device,
             baudrate,
             bytesize,
@@ -172,45 +186,261 @@ class AioHtHeatpump(HtHeatpump):
             verify_param_action,
             verify_param_error,
         )
-        # update the settings for later connection establishment
-        self._ser_settings.update(
-            {
-                "loop": loop,
-                "cancel_read_timeout": cancel_read_timeout,
-                "cancel_write_timeout": cancel_write_timeout,
-            }
-        )
+
+        # Async specific attributes
+        self._loop = loop # Store loop, might be None initially
         self._lock = asyncio.Lock()
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        # _ser (aioserial instance) is handled below
+
+        # update the settings for later connection establishment
+        if self._ser_settings:
+            # Ensure loop is available for aioserial
+            if self._loop is None:
+                 try:
+                     self._loop = asyncio.get_running_loop()
+                 except RuntimeError:
+                     # If no loop running, create one (less ideal, depends on context)
+                     # Or raise an error if loop is strictly required
+                     # self._loop = asyncio.new_event_loop()
+                     # asyncio.set_event_loop(self._loop)
+                     raise RuntimeError("asyncio event loop is required for AioHtHeatpump with serial.")
+
+            self._ser_settings.update(
+                {
+                    "loop": self._loop,
+                    "cancel_read_timeout": cancel_read_timeout,
+                    "cancel_write_timeout": cancel_write_timeout,
+                }
+            )
+            # Initialize aioserial instance (but don't open yet)
+            # Parent __init__ sets self._ser to None, override here
+            self._ser = aioserial.AioSerial(**self._ser_settings)
+        else:
+            # If URL is used, parent __init__ sets self._ser to None, which is correct
+            self._ser = None
+
+        # _sock_settings is populated by parent __init__ if url was provided
+
+    # --- Connection Management ---
 
     def open_connection(self) -> None:
         """Open the serial connection with the defined settings.
 
-        :raises IOError:
-            When the serial connection is already open.
-        :raises ValueError:
-            Will be raised when parameter are out of range, e.g. baudrate, bytesize.
-        :raises SerialException:
-            In case the device can not be found or can not be configured.
+        :raises IOError: If the connection objects indicate it's already open.
+        :raises RuntimeError: If neither serial nor TCP is configured.
         """
-        if self._ser:
-            raise IOError("serial connection already open")
-        # open the serial connection (must fit with the settings on the heat pump!)
-        self._ser = aioserial.AioSerial(**self._ser_settings)
-        _LOGGER.info(self._ser)  # log serial connection properties
+        if self.is_open:
+             raise IOError("connection objects indicate an open connection.")
+
+        # Reset async state variables
+        self._reader = None
+        self._writer = None
+        # Re-initialize aioserial instance if needed (settings might have changed)
+        if self._ser_settings:
+            if self._ser and self._ser.is_open:
+                 self._ser.close() # Close existing if open
+            # Ensure loop is available
+            if self._loop is None:
+                 try:
+                     self._loop = asyncio.get_running_loop()
+                 except RuntimeError:
+                     raise RuntimeError("asyncio event loop is required for AioHtHeatpump with serial.")
+            # Update loop in settings if it was None before
+            self._ser_settings["loop"] = self._loop
+            self._ser = aioserial.AioSerial(**self._ser_settings)
+            _LOGGER.info("prepared serial connection: %s", self._ser)
+        elif self._sock_settings:
+             _LOGGER.info("prepared TCP connection settings: %s", self._sock_settings)
+        else:
+            raise RuntimeError("neither serial nor socket settings are configured.")
+
+    async def connect_async(self) -> None:
+        """Establishes the asynchronous connection (Serial or TCP)."""
+        if self.is_open:
+            _LOGGER.debug("connection already open, skipping connect_async.")
+            return
+
+        if self._ser_settings:
+            if not self._ser:
+                 raise RuntimeError("serial instance not prepared. Call open_connection first.")
+            if not self._ser.is_open:
+                 try:
+                     # aioserial opens implicitly, but let's ensure it
+                     # A simple check or triggering an operation might be needed
+                     # Forcing open if possible, or relying on first IO
+                     # Let's try to trigger opening via a zero-byte read
+                     await self._ser.read_async(0)
+                     _LOGGER.info("serial connection confirmed open: %s", self._ser)
+                 except (aioserial.SerialException, OSError) as e:
+                     _LOGGER.error("failed to open serial connection %s: %s", self._ser.port, e)
+                     raise IOError(f"failed to open serial connection {self._ser.port}: {e}") from e
+
+        elif self._sock_settings:
+            host, port = self._sock_settings["address"]
+            # Use timeout from settings, fallback to default
+            timeout = self._sock_settings.get("timeout")
+            if timeout is None: timeout = self.DEFAULT_TIMEOUT
+
+            try:
+                _LOGGER.debug("attempting to open TCP connection to %s:%s with timeout %s", host, port, timeout)
+                self._reader, self._writer = await asyncio.wait_for(
+                    asyncio.open_connection(host, port),
+                    timeout=timeout
+                )
+                _LOGGER.info("TCP connection established successfully to %s:%s", host, port)
+            except asyncio.TimeoutError:
+                 _LOGGER.error("TCP connection timed out to %s:%s", host, port)
+                 raise IOError(f"TCP connection timed out to {host}:{port}") from None
+            except (socket.gaierror, ConnectionRefusedError, OSError) as e:
+                 _LOGGER.error("TCP connection failed to %s:%s: %s", host, port, e)
+                 # Close potentially partially opened streams on failure
+                 if self._writer:
+                     self._writer.close()
+                     # await self._writer.wait_closed() # Might hang if connection failed badly
+                 self._reader = None
+                 self._writer = None
+                 raise IOError(f"TCP connection failed to {host}:{port}: {e}") from e
+        else:
+            raise RuntimeError("neither serial nor socket settings are configured.")
+
+    async def close_connection_async(self) -> None:
+        """Close the established asynchronous connection."""
+        if self._ser_settings:
+            if self._ser and self._ser.is_open:
+                try:
+                    self._ser.close()
+                    _LOGGER.info("serial connection closed.")
+                except Exception as e:
+                    _LOGGER.warning("error closing serial connection: %s", e)
+                finally:
+                    self._ser = None # Ensure instance is cleared
+                    await asyncio.sleep(0.1) # Keep delay
+        elif self._sock_settings:
+            if self._writer:
+                try:
+                    if not self._writer.is_closing():
+                        self._writer.close()
+                        await self._writer.wait_closed()
+                        _LOGGER.info("TCP connection closed.")
+                    else:
+                        _LOGGER.debug("TCP writer already closing.")
+                except Exception as e:
+                    _LOGGER.warning("error closing TCP writer: %s", e)
+                finally:
+                    self._writer = None # Ensure cleared
+                    self._reader = None # Ensure cleared
+                    await asyncio.sleep(0.1) # Keep delay
+
+        # Ensure state is reset even if already closed or error occurred
+        self._ser = None
+        self._reader = None
+        self._writer = None
+
+    def close_connection(self) -> None:
+        """Close the connection (Synchronous wrapper - Use with caution)."""
+        if self.is_open:
+             _LOGGER.warning("close_connection called synchronously on AioHtHeatpump. Use close_connection_async.")
+             # Try sync close for serial if possible
+             if self._ser and self._ser.is_open:
+                 try:
+                     self._ser.close()
+                     time.sleep(0.1)
+                 except Exception as e:
+                     _LOGGER.error("synchronous close of aioserial failed: %s", e)
+             elif self._writer:
+                 _LOGGER.error("cannot synchronously close active async TCP connection. Use close_connection_async.")
+             # Reset state regardless
+             self._ser = None
+             self._reader = None
+             self._writer = None
+        else:
+             # Ensure state is reset if called when not open
+             self._ser = None
+             self._reader = None
+             self._writer = None
+
+
+    async def reconnect_async(self) -> None:
+        """Reconnect asynchronously (close, prepare, connect)."""
+        _LOGGER.info("attempting to reconnect...")
+        await self.close_connection_async()
+        # open_connection is sync and just prepares settings/instances
+        self.open_connection()
+        # connect_async actually establishes the connection
+        await self.connect_async()
+        _LOGGER.info("reconnection attempt finished.")
+
+    def reconnect(self) -> None:
+        """Synchronous reconnect wrapper (Not Recommended)."""
+        _LOGGER.warning("reconnect called synchronously on AioHtHeatpump. Use reconnect_async.")
+        raise NotImplementedError("synchronous reconnect is not supported. Use reconnect_async.")
+
+    @property
+    def is_open(self) -> bool:
+        """Return the state of the asynchronous connection."""
+        if self._ser_settings:
+            # Check aioserial instance and its state
+            return self._ser is not None and self._ser.is_open
+        elif self._sock_settings:
+            # Check if writer exists and is not closing/closed
+            return self._writer is not None and not self._writer.is_closing()
+        return False
+
+    # --- Communication Methods ---
 
     async def send_request_async(self, cmd: str) -> None:
-        """Send a request to the heat pump.
+        """Send a request asynchronously to the heat pump."""
+        if not self.is_open:
+            # Try to connect if not open? Or raise error? Raising is safer.
+            raise IOError("connection not open")
 
-        :param cmd: Command to send to the heat pump.
-        :type cmd: str
-        :raises IOError:
-            Will be raised when the serial connection is not open.
-        """
-        if not self._ser:
-            raise IOError("serial connection not open")
         req = create_request(cmd)
-        _LOGGER.debug("send request: [%s]", req)
-        await self._ser.write_async(req)
+        _LOGGER.debug("send async request: [%s]", req)
+
+        try:
+            if self._ser_settings:
+                if not self._ser: raise IOError("serial connection not initialized")
+                await self._ser.write_async(req)
+                # await self._ser.drain_async() # Usually not needed for serial
+            elif self._sock_settings:
+                if not self._writer: raise IOError("TCP connection not established")
+                self._writer.write(req)
+                await self._writer.drain() # Ensure data is sent over TCP
+            else:
+                # This case should be prevented by __init__
+                raise RuntimeError("neither serial, nor socket settings are configured")
+        except (aioserial.SerialException, socket.error, OSError, BrokenPipeError) as e:
+            _LOGGER.error("Failed to send async request: %s", e)
+            # Connection likely broken, close it
+            await self.close_connection_async()
+            raise IOError(f"failed to send async request: {e}") from e
+
+    async def _socket_recvall_async(self, size: int) -> bytes:
+        """Receive exactly size bytes asynchronously from TCP socket."""
+        if not self._reader:
+            raise IOError("TCP connection not established or reader is missing")
+
+        # Use timeout from settings for the read operation
+        timeout = self._sock_settings.get("timeout") if self._sock_settings else None
+        if timeout is None: timeout = self.DEFAULT_TIMEOUT
+
+        try:
+            data = await asyncio.wait_for(self._reader.readexactly(size), timeout=timeout)
+            return data
+        except asyncio.TimeoutError:
+            _LOGGER.error("socket read timed out waiting for %d bytes", size)
+            await self.close_connection_async()
+            raise IOError(f"socket read timed out waiting for {size} bytes") from None
+        except asyncio.IncompleteReadError as e:
+            _LOGGER.error("socket connection closed or broke during readexactly (expected %d, got %d)", size, len(e.partial))
+            await self.close_connection_async()
+            raise IOError(f"socket connection closed or broke during read (expected {size}, got {len(e.partial)})") from e
+        except (socket.error, OSError) as e:
+            _LOGGER.error("socket error during readexactly: %s", e)
+            await self.close_connection_async()
+            raise IOError(f"socket error during read: {e}") from e
 
     async def read_response_async(self) -> str:
         """Read the response message from the heat pump.
@@ -246,84 +476,174 @@ class AioHtHeatpump(HtHeatpump):
             must be corrected (for the checksum computation) so that the received checksum fits with the computed
             one (e.g. for ``b"\\x02\\xfd\\xe0\\xd0\\x01\\x00"`` and ``b"\\x02\\xfd\\xe0\\xd0\\x02\\x00"``).
         """
-        if not self._ser:
-            raise IOError("serial connection not open")
-        # read the header of the response message
-        header = await self._ser.read_async(RESPONSE_HEADER_LEN)
-        if not header:
-            raise IOError("data stream broken during reading response header")
+        if not self.is_open:
+            raise IOError("connection not open")
+
+        # Determine read timeout
+        read_timeout: Optional[Union[float, int]] = None
+        if self._ser_settings:
+            read_timeout = self._ser.timeout if self._ser else self.DEFAULT_TIMEOUT
+        elif self._sock_settings:
+            read_timeout = self._sock_settings.get("timeout", self.DEFAULT_TIMEOUT)
+        if read_timeout is None: read_timeout = self.DEFAULT_TIMEOUT # Ensure a value
+
+        # Read header
+        try:
+            if self._ser_settings:
+                if not self._ser: raise IOError("serial connection not initialized")
+                header = await asyncio.wait_for(self._ser.read_async(RESPONSE_HEADER_LEN), timeout=read_timeout)
+            elif self._sock_settings:
+                header = await self._socket_recvall_async(RESPONSE_HEADER_LEN) # Uses internal timeout
+            else:
+                raise RuntimeError("neither serial, nor socket settings are configured.")
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+             _LOGGER.error("failed reading response header: %s", e)
+             await self.close_connection_async()
+             raise IOError(f"failed reading response header: {e}") from e
+
+        if not header or len(header) < RESPONSE_HEADER_LEN:
+            await self.close_connection_async()
+            raise IOError(f"data stream broken reading header (incomplete: {header!r})")
         elif header not in RESPONSE_HEADER:
-            raise IOError("invalid or unknown response header [{}]".format(header))
-        # read the length of the following payload
-        payload_len_r = await self._ser.read_async(1)
-        if not payload_len_r:
-            raise IOError("data stream broken during reading payload length")
-        payload_len = payload_len_r = payload_len_r[0]
-        # We don't know why, but for some messages (e.g. for the error message "ERR,INVALID IDX") the
-        # heat pump answers with a payload length of zero bytes. In order to also accept such responses
-        # we read until we will found the trailing "\r\n" at the end of the payload. The payload length
-        # itself will then be computed afterwards by counting the number of bytes of the payload.
-        if payload_len == 0:
-            _LOGGER.info(
-                "received response with a payload length of zero;"
-                " try to read until the occurrence of '\\r\\n' [header=%s]",
-                header,
-            )
-            payload = b""
-            while payload[-2:] != b"\r\n":
-                tmp = await self._ser.read_async(1)
-                if not tmp:
-                    raise IOError(
-                        "data stream broken during reading payload ending with '\\r\\n'"
-                    )
-                payload += tmp
-            # compute the payload length by counting the number of read bytes
-            payload_len = len(payload)
-        else:
-            # read the payload itself
-            payload = await self._ser.read_async(payload_len)
-            if not payload or len(payload) < payload_len:
-                raise IOError("data stream broken during reading payload")
-        # depending on the received header correct the payload length for the checksum computation,
-        #   so that the received checksum fits with the computed one
-        payload_len = RESPONSE_HEADER[header]["payload_len"](payload_len)
-        # read the checksum and verify the validity of the response
-        checksum = await self._ser.read_async(1)
-        if not checksum:
-            raise IOError("data stream broken during reading checksum")
-        checksum = checksum[0]
-        # compute the checksum over header, payload length and the payload itself (depending on the header)
-        comp_checksum = RESPONSE_HEADER[header]["checksum"](
-            header, payload_len, payload
+            _LOGGER.error("invalid or unknown response header received: %r", header)
+            await self.close_connection_async()
+            raise IOError(f"invalid or unknown response header [{header!r}]")
+
+        # Read payload length byte
+        try:
+            if self._ser_settings:
+                if not self._ser: raise IOError("serial connection not initialized")
+                payload_len_r_bytes = await asyncio.wait_for(self._ser.read_async(1), timeout=read_timeout)
+            else: # Socket
+                payload_len_r_bytes = await self._socket_recvall_async(1) # Uses internal timeout
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+             _LOGGER.error("failed reading payload length: %s", e)
+             await self.close_connection_async()
+             raise IOError(f"failed reading payload length: {e}") from e
+
+        if not payload_len_r_bytes:
+            await self.close_connection_async()
+            raise IOError("data stream broken reading payload length (empty byte)")
+
+        payload_len_r = payload_len_r_bytes[0]
+        # payload_len will be corrected later for checksum
+
+        # Read payload
+        payload: bytes
+        actual_payload_len: int
+
+        try:
+            if payload_len_r == 0:
+                _LOGGER.info("received response with a payload length zero; reading until '\\r\\n' [header=%r]", header)
+                payload = b""
+                # Use a loop with timeout for each byte read
+                loop_start_time = asyncio.get_running_loop().time()
+                while payload[-2:] != b"\r\n":
+                    # Check overall timeout for this loop
+                    if (asyncio.get_running_loop().time() - loop_start_time) > read_timeout:
+                        raise asyncio.TimeoutError("overall timeout while reading payload ending with '\\r\\n'")
+
+                    try:
+                        # Read one byte with a smaller, per-byte timeout or rely on overall
+                        byte_timeout = min(0.5, read_timeout) # Example: 0.5s per byte
+                        if self._ser_settings:
+                            if not self._ser: raise IOError("serial connection not initialized")
+                            tmp = await asyncio.wait_for(self._ser.read_async(1), timeout=byte_timeout)
+                        else: # Socket
+                            tmp = await asyncio.wait_for(self._socket_recvall_async(1), timeout=byte_timeout)
+
+                        if not tmp:
+                            raise IOError("data stream broken (received empty byte)")
+                        payload += tmp
+                    except asyncio.TimeoutError:
+                         # This might happen if there's a pause, continue loop if overall timeout not exceeded
+                         _LOGGER.debug("per-byte read timeout, continuing if overall time allows.")
+                         continue # Or raise immediately: raise IOError("Timeout while reading payload chunk (len=0)") from None
+                    except (IOError, aioserial.SerialException, socket.error, OSError) as e:
+                         raise IOError(f"failed reading payload chunk (len=0): {e}") from e
+
+                actual_payload_len = len(payload)
+            else:
+                # Read payload_len_r bytes
+                if self._ser_settings:
+                    if not self._ser: raise IOError("serial connection not initialized")
+                    payload = await asyncio.wait_for(self._ser.read_async(payload_len_r), timeout=read_timeout)
+                else: # Socket
+                    payload = await self._socket_recvall_async(payload_len_r) # Uses internal timeout
+
+                if not payload or len(payload) < payload_len_r:
+                    raise IOError(f"data stream broken reading payload (incomplete, expected {payload_len_r}, got {len(payload)})")
+                actual_payload_len = len(payload)
+
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+             _LOGGER.error("failed reading payload: %s", e)
+             await self.close_connection_async()
+             raise IOError(f"failed reading payload: {e}") from e
+
+        # Correct payload length for checksum computation based on header
+        # Call the function to get the corrected length value
+        corrected_payload_len_val = RESPONSE_HEADER[header]["payload_len"](payload_len_r)
+
+        # Read checksum byte
+        try:
+            if self._ser_settings:
+                if not self._ser: raise IOError("serial connection not initialized")
+                checksum_bytes = await asyncio.wait_for(self._ser.read_async(1), timeout=read_timeout)
+            else: # Socket
+                checksum_bytes = await self._socket_recvall_async(1) # Uses internal timeout
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+             _LOGGER.error("failed reading checksum: %s", e)
+             await self.close_connection_async()
+             raise IOError(f"failed reading checksum: {e}") from e
+
+        if not checksum_bytes:
+            await self.close_connection_async()
+            raise IOError("data stream broken reading checksum (empty byte)")
+        checksum = checksum_bytes[0]
+
+        # Compute and verify checksum
+        # Call the function to get the computed checksum value
+        comp_checksum_val = RESPONSE_HEADER[header]["checksum"](
+            header, corrected_payload_len_val, payload
         )
-        if checksum != comp_checksum:
-            raise IOError(
-                "invalid checksum [{}] of response "
-                "[header={}, payload_len={:d}({:d}), payload={}, checksum={}]".format(
-                    hex(checksum),
-                    header,
-                    payload_len,
-                    payload_len_r,
-                    payload,
-                    hex(comp_checksum),
-                )
+
+        # Compare the integer checksum values
+        if checksum != comp_checksum_val:
+            # Use the calculated values in the error message
+            error_msg = (
+                f"invalid checksum [{checksum:#04x}] of response "
+                f"[header={header!r}, payload_len={corrected_payload_len_val}(orig={payload_len_r}), "
+                f"payload={payload!r}, expected_checksum={comp_checksum_val:#04x}]"
             )
-        # debug log of the received response
-        _LOGGER.debug(
-            "received response: %s",
-            header + bytes([payload_len]) + payload + bytes([checksum]),
-        )
-        _LOGGER.debug("  header = %s", header)
-        _LOGGER.debug("  payload length = %d(%d)", payload_len, payload_len_r)
-        _LOGGER.debug("  payload = %s", payload)
-        _LOGGER.debug("  checksum = %s", hex(checksum))
-        # extract the relevant data from the payload (without header '~' and trailer ';\r\n')
-        m = re.match(r"^~([^;]*);\r\n$", payload.decode("ascii"))
-        if not m:
-            raise IOError(
-                "failed to extract response data from payload [{}]".format(payload)
-            )
-        return m.group(1)
+            _LOGGER.error(error_msg)
+            await self.close_connection_async()
+            raise IOError(error_msg)
+
+        # Debug log
+        _LOGGER.debug("received async response raw: %s", header + payload_len_r_bytes + payload + checksum_bytes)
+        _LOGGER.debug("  header = %r", header)
+        # Use the calculated value in the debug log
+        _LOGGER.debug("  payload length = %d (orig=%d, actual=%d)", corrected_payload_len_val, payload_len_r, actual_payload_len)
+        _LOGGER.debug("  payload = %r", payload)
+        _LOGGER.debug("  checksum = %#04x", checksum)
+        
+        # Extract data
+        try:
+            decoded_payload = payload.decode("ascii")
+            m = re.match(r"^~([^;]*);\r\n$", decoded_payload)
+            if not m:
+                raise IOError(f"failed to extract response data from payload [{payload!r}]")
+            return m.group(1)
+        except UnicodeDecodeError as e:
+            _LOGGER.error("failed to decode payload as ASCII: %s [%r]", e, payload)
+            await self.close_connection_async()
+            raise IOError(f"failed to decode payload as ASCII: {e} [{payload!r}]") from e
+        except IOError as e:
+             _LOGGER.error("error extracting data: %s", e)
+             await self.close_connection_async()
+             raise e # Re-raise the extraction error
+
+    # --- Async API Methods ---
 
     async def login_async(
         self,
@@ -347,53 +667,65 @@ class AioHtHeatpump(HtHeatpump):
             response (e.g. broken data stream, invalid checksum).
         """
         async with self._lock:
-            # we try to login the heat pump for several times
+            # Ensure connection is established before login attempt
+            await self.connect_async() # Ensures connection is open
+
             success = False
             retry = 0
             while not success and retry <= max_retries:
-                # send LOGIN request to the heat pump
-                await self.send_request_async(LOGIN_CMD)
-                # ... and wait for the response
                 try:
+                    await self.send_request_async(LOGIN_CMD)
                     resp = await self.read_response_async()
                     m = re.match(LOGIN_RESP, resp)
                     if not m:
-                        raise IOError(
-                            "invalid response for LOGIN command [{!r}]".format(resp)
-                        )
-                    else:
-                        success = True
+                        raise IOError(f"invalid response for LOGIN command [{resp!r}]")
+                    success = True
                 except Exception as ex:
                     retry += 1
                     _LOGGER.warning("login try #%d failed: %s", retry, ex)
-                    # try a reconnect, maybe this will help ;-)
-                    self.reconnect()
+                    if retry <= max_retries:
+                        _LOGGER.info("attempting reconnect after failed login...")
+                        try:
+                            await self.reconnect_async()
+                        except Exception as recon_ex:
+                            _LOGGER.error("reconnect failed: %s", recon_ex)
+                            break # Stop retrying if reconnect fails
+                        await asyncio.sleep(0.2 * retry) # Slight backoff
+
             if not success:
                 _LOGGER.error("login failed after %d try/tries", retry)
-                raise IOError("login failed after {:d} try/tries".format(retry))
-            _LOGGER.info("login successfully")
-            # perform a limits update of all parameters (if desired)
+                await self.close_connection_async() # Ensure closed on final failure
+                raise IOError(f"login failed after {retry} try/tries")
+
+            _LOGGER.info("login successful")
             if update_param_limits:
                 await self.update_param_limits_async()
 
     async def logout_async(self) -> None:
-        """Log out from the heat pump session."""
+        """Log out from the heat pump session asynchronously and close connection."""
+        if not self.is_open:
+             _LOGGER.info("connection already closed, skipping logout.")
+             return
+
+        # Use lock to prevent concurrent operations during logout/close
         async with self._lock:
+            # Check again inside lock
+            if not self.is_open:
+                 _LOGGER.info("connection closed before logout could proceed.")
+                 return
             try:
-                # send LOGOUT request to the heat pump
                 await self.send_request_async(LOGOUT_CMD)
-                # ... and wait for the response
                 resp = await self.read_response_async()
                 m = re.match(LOGOUT_RESP, resp)
                 if not m:
-                    raise IOError(
-                        "invalid response for LOGOUT command [{!r}]".format(resp)
-                    )
-                _LOGGER.info("logout successfully")
+                    _LOGGER.warning(f"invalid response for LOGOUT command [{resp!r}]")
+                else:
+                    _LOGGER.info("logout successful")
             except Exception as ex:
-                # just a warning, because it's possible that we can continue without any further problems
-                _LOGGER.warning("logout failed: %s", ex)
-                # raise  # logout_async() should not fail!
+                _LOGGER.warning("logout command failed: %s", ex)
+            finally:
+                 # Always close the connection after attempting logout
+                 await self.close_connection_async()
 
     async def get_serial_number_async(self) -> int:
         """Query for the manufacturer's serial number of the heat pump.
@@ -917,42 +1249,6 @@ class AioHtHeatpump(HtHeatpump):
                 return ret
             except Exception as ex:
                 _LOGGER.error("set parameter '%s' failed: %s", name, ex)
-                raise
-
-    async def overwrite_param_async(
-        self, name: str, val: Optional[HtParamValueType], ignore_limits: bool = False
-    ) -> HtParamValueType:
-        """TODO doc
-        """
-        async with self._lock:
-            # find the corresponding definition for the parameter
-            if name not in HtParams:
-                raise KeyError(
-                    "parameter definition for parameter {!r} not found".format(name)
-                )
-            param = HtParams[name]  # type: ignore
-            # check the passed value against the defined limits (if desired)
-            if not ignore_limits and not param.in_limits(val):
-                raise ValueError(
-                    "value {!r} is beyond the limits [{}, {}]".format(
-                        val, param.min_val, param.max_val
-                    )
-                )
-            # send command to the heat pump
-            if val is None:
-                await self.send_request_async("{},ORF=0".format(param.cmd()))
-            else:
-                val = param.to_str(val)
-                await self.send_request_async("{},ORV={},ORF=1".format(param.cmd(), val))
-            # ... and wait for the response
-            try:
-                resp = await self.read_response_async()
-                data = self._extract_param_data(name, resp)
-                ret = self._verify_param_resp(name, *data)
-                _LOGGER.debug("'%s' = %s", name, ret)
-                return ret  # type: ignore
-            except Exception as e:
-                _LOGGER.error("overwrite parameter '%s' failed: %s", name, e)
                 raise
 
     @property

--- a/htheatpump/scripts/htbackup.py
+++ b/htheatpump/scripts/htbackup.py
@@ -24,13 +24,15 @@
     .. code-block:: shell
 
        $ python3 htbackup.py --baudrate 9600 --csv backup.csv
-       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4', ORV='', ORF=''
-       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1', ORV='', ORF=''
-       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1', ORV='', ORF=''
+       or
+       $ python3 htbackup.py --url "tcp://localhost:9999" --csv backup.csv
+       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
+       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
+       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
        ...
-       'MP,NR=0' [Temp. Aussen]: VAL='3.5', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='3.8', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=2' [Temp. Brauchwasser]: VAL='46.1', MIN='0.0', MAX='70.0', ORV='0.0', ORF='0'
+       'MP,NR=0' [Temp. Aussen]: VAL='-7.0', MIN='-20.0', MAX='40.0'
+       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='-6.9', MIN='-20.0', MAX='40.0'
+       'MP,NR=2' [Temp. Brauchwasser]: VAL='45.7', MIN='0.0', MAX='70.0'
        ...
 """
 
@@ -59,6 +61,8 @@ def main() -> None:
             Example:
 
               $ python3 htbackup.py --baudrate 9600 --csv backup.csv
+              or
+              $ python3 htbackup.py --url "tcp://localhost:9999" --csv backup.csv
               'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
               'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
               'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
@@ -84,6 +88,11 @@ def main() -> None:
         + "\r\n",
     )
 
+    parser.add_argument(
+        "-u", "--url", type=str,
+        help="the TCP URL (e.g., tcp://192.168.1.100:9999). Provide either --device or --url.",
+    )
+    
     parser.add_argument(
         "-d",
         "--device",
@@ -135,7 +144,15 @@ def main() -> None:
         help="maximum number of retries for a data point request (0..10), default: %(default)s",
     )
 
+    parser.add_argument(
+        "--timeout", type=float, default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
+
+    if not args.device and not args.url:
+        parser.error("Either --device or --url must be specified.")
 
     # activate logging with level DEBUG in verbose mode
     log_format = "%(asctime)s %(levelname)s [%(name)s|%(funcName)s]: %(message)s"
@@ -144,8 +161,14 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if args.url:
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose: _LOGGER.info("Using TCP connection: %s", args.url)
+        else: # args.device must be set
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose: _LOGGER.info("Using serial connection: %s", args.device)
+        
         hp.open_connection()
         hp.login()
 
@@ -169,35 +192,28 @@ def main() -> None:
                         # ... and wait for the response
                         try:
                             resp = hp.read_response()
-                            # search for pattern "NAME=...", "VAL=...", "MAX=...", "MIN=...",
-                            #   "ORV=..." and "ORF=..." inside the answer
+                            # search for pattern "NAME=...", "VAL=...", "MAX=..." and "MIN=..." inside the answer
                             m = re.match(
-                                r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+)"
-                                r".*ORV=([^,]+).*ORF=([^,]+).*$".format(data_point),
+                                r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(
+                                    data_point
+                                ),
                                 resp,
                             )
-                            if m:
-                                # extract name, value, min, max, orv and orf
-                                name, value, min_val, max_val, orv, orf = (
-                                    g.strip() for g in m.group(1, 2, 4, 3, 5, 6)
-                                )
-                            else:
-                                m = re.match(
-                                    r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(data_point),
-                                    resp,
-                                )
-                                if not m:
-                                    raise IOError(
-                                        "invalid response for query of data point {!r} [{}]".format(data_point, resp)
+                            if not m:
+                                raise IOError(
+                                    "invalid response for query of data point {!r} [{}]".format(
+                                        data_point, resp
                                     )
-                                # extract name, value, min and max
-                                name, value, min_val, max_val = (g.strip() for g in m.group(1, 2, 4, 3))
-                                orv = orf = ""
+                                )
+                            # extract name, value, min and max
+                            name, value, min_val, max_val = (
+                                g.strip() for g in m.group(1, 2, 4, 3)
+                            )
                             if args.without_values:
-                                value = orv = ""  # keep it blank (if desired)
+                                value = ""  # keep it blank (if desired)
                             print(
-                                "{!r} [{}]: VAL={!r}, MIN={!r}, MAX={!r}, ORV={!r}, ORF={!r}".format(
-                                    data_point, name, value, min_val, max_val, orv, orf
+                                "{!r} [{}]: VAL={!r}, MIN={!r}, MAX={!r}".format(
+                                    data_point, name, value, min_val, max_val
                                 )
                             )
                             # store the determined data in the result dict
@@ -208,8 +224,6 @@ def main() -> None:
                                         "value": value,
                                         "min": min_val,
                                         "max": max_val,
-                                        "orv": orv,
-                                        "orf": orf,
                                     }
                                 }
                             )
@@ -245,8 +259,8 @@ def main() -> None:
                 json.dump(result, jsonfile, indent=4, sort_keys=True)
 
         if args.csv:  # write result to CSV file
-            with open(args.csv, "w") as csvfile:
-                fieldnames = ["type", "number", "name", "value", "min", "max", "orv", "orf"]
+            with open(args.csv, "w", encoding="utf-8") as csvfile:
+                fieldnames = ["type", "number", "name", "value", "min", "max"]
                 writer = csv.DictWriter(csvfile, delimiter=",", fieldnames=fieldnames)
                 writer.writeheader()
                 for dp_type, content in sorted(result.items(), reverse=True):

--- a/htheatpump/scripts/htbackup_async.py
+++ b/htheatpump/scripts/htbackup_async.py
@@ -24,13 +24,15 @@
     .. code-block:: shell
 
        $ python3 htbackup_async.py --baudrate 9600 --csv backup.csv
-       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4', ORV='', ORF=''
-       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1', ORV='', ORF=''
-       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1', ORV='', ORF=''
+       or
+       $ python3 htbackup_async.py --url "tcp://localhost:9999" --csv backup.csv
+       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
+       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
+       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
        ...
-       'MP,NR=0' [Temp. Aussen]: VAL='3.5', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='3.8', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=2' [Temp. Brauchwasser]: VAL='46.1', MIN='0.0', MAX='70.0', ORV='0.0', ORF='0'
+       'MP,NR=0' [Temp. Aussen]: VAL='-7.0', MIN='-20.0', MAX='40.0'
+       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='-6.9', MIN='-20.0', MAX='40.0'
+       'MP,NR=2' [Temp. Brauchwasser]: VAL='45.7', MIN='0.0', MAX='70.0'
        ...
 """
 
@@ -60,6 +62,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htbackup_async.py --baudrate 9600 --csv backup.csv
+              or
+              $ python3 htbackup_async.py --url "tcp://localhost:9999" --csv backup.csv
               'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
               'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
               'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
@@ -83,6 +87,11 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u", "--url", type=str,
+        help="the TCP URL (e.g., tcp://192.168.1.100:9999). Provide either --device or --url.",
     )
 
     parser.add_argument(
@@ -136,7 +145,15 @@ async def main_async() -> None:
         help="maximum number of retries for a data point request (0..10), default: %(default)s",
     )
 
+    parser.add_argument(
+        "--timeout", type=float, default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
+
+    if not args.device and not args.url:
+        parser.error("Either --device or --url must be specified.")
 
     # activate logging with level DEBUG in verbose mode
     log_format = "%(asctime)s %(levelname)s [%(name)s|%(funcName)s]: %(message)s"
@@ -145,8 +162,14 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if args.url:
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose: _LOGGER.info("Using TCP connection: %s", args.url)
+        else: # args.device must be set
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose: _LOGGER.info("Using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -170,35 +193,28 @@ async def main_async() -> None:
                         # ... and wait for the response
                         try:
                             resp = await hp.read_response_async()
-                            # search for pattern "NAME=...", "VAL=...", "MAX=...", "MIN=...",
-                            #   "ORV=..." and "ORF=..." inside the answer
+                            # search for pattern "NAME=...", "VAL=...", "MAX=..." and "MIN=..." inside the answer
                             m = re.match(
-                                r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+)"
-                                r".*ORV=([^,]+).*ORF=([^,]+).*$".format(data_point),
+                                r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(
+                                    data_point
+                                ),
                                 resp,
                             )
-                            if m:
-                                # extract name, value, min, max, orv and orf
-                                name, value, min_val, max_val, orv, orf = (
-                                    g.strip() for g in m.group(1, 2, 4, 3, 5, 6)
-                                )
-                            else:
-                                m = re.match(
-                                    r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(data_point),
-                                    resp,
-                                )
-                                if not m:
-                                    raise IOError(
-                                        "invalid response for query of data point {!r} [{}]".format(data_point, resp)
+                            if not m:
+                                raise IOError(
+                                    "invalid response for query of data point {!r} [{}]".format(
+                                        data_point, resp
                                     )
-                                # extract name, value, min and max
-                                name, value, min_val, max_val = (g.strip() for g in m.group(1, 2, 4, 3))
-                                orv = orf = ""
+                                )
+                            # extract name, value, min and max
+                            name, value, min_val, max_val = (
+                                g.strip() for g in m.group(1, 2, 4, 3)
+                            )
                             if args.without_values:
-                                value = orv = ""  # keep it blank (if desired)
+                                value = ""  # keep it blank (if desired)
                             print(
-                                "{!r} [{}]: VAL={!r}, MIN={!r}, MAX={!r}, ORV={!r}, ORF={!r}".format(
-                                    data_point, name, value, min_val, max_val, orv, orf
+                                "{!r} [{}]: VAL={!r}, MIN={!r}, MAX={!r}".format(
+                                    data_point, name, value, min_val, max_val
                                 )
                             )
                             # store the determined data in the result dict
@@ -209,8 +225,6 @@ async def main_async() -> None:
                                         "value": value,
                                         "min": min_val,
                                         "max": max_val,
-                                        "orv": orv,
-                                        "orf": orf,
                                     }
                                 }
                             )
@@ -225,7 +239,7 @@ async def main_async() -> None:
                                 ex,
                             )
                             # try a reconnect, maybe this will help
-                            hp.reconnect()  # perform a reconnect
+                            await hp.reconnect_async()  # perform a reconnect
                             try:
                                 await hp.login_async(
                                     max_retries=0
@@ -248,8 +262,8 @@ async def main_async() -> None:
                 json.dump(result, jsonfile, indent=4, sort_keys=True)
 
         if args.csv:  # write result to CSV file
-            with open(args.csv, "w") as csvfile:
-                fieldnames = ["type", "number", "name", "value", "min", "max", "orv", "orf"]
+            with open(args.csv, "w", encoding="utf-8") as csvfile:
+                fieldnames = ["type", "number", "name", "value", "min", "max"]
                 writer = csv.DictWriter(csvfile, delimiter=",", fieldnames=fieldnames)
                 writer.writeheader()
                 for dp_type, content in sorted(result.items(), reverse=True):
@@ -267,7 +281,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htcomplparams.py
+++ b/htheatpump/scripts/htcomplparams.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htcomplparams.py --device /dev/ttyUSB1 --baudrate 9600 --csv
+       or
+       $ python3 htcomplparams.py --url "tcp://localhost:9999" --csv
        connected successfully to heat pump with serial number 123456
        software version = 3.0.20 (273)
        'SP,NR=0' [Language]: VAL=0, MIN=0, MAX=4 (dtype=INT)
@@ -59,6 +61,8 @@ def main() -> None:
             Example:
 
               $ python3 htcomplparams.py --device /dev/ttyUSB1 --baudrate 9600 --csv
+              or
+              $ python3 htcomplparams.py --url "tcp://localhost:9999" --csv
               connected successfully to heat pump with serial number 123456
               software version = 3.0.20 (273)
               'SP,NR=0' [Language]: VAL=0, MIN=0, MAX=4 (dtype=INT)
@@ -85,6 +89,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -133,6 +144,14 @@ def main() -> None:
         help="maximum number of retries for a data point request (0..10), default: %(default)s",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -142,8 +161,18 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htdatetime.py
+++ b/htheatpump/scripts/htdatetime.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htdatetime.py --device /dev/ttyUSB1 --baudrate 9600
+       or
+       $ python3 htdatetime.py --url "tcp://localhost:9999"
        Tuesday, 2017-11-21T21:48:04
        $ python3 htdatetime.py -d /dev/ttyUSB1 -b 9600 "2008-09-03T20:56:35"
        Wednesday, 2008-09-03T20:56:35
@@ -69,6 +71,8 @@ def main() -> None:
             Example:
 
               $ python3 htdatetime.py --device /dev/ttyUSB1 --baudrate 9600
+              or
+              $ python3 htdatetime.py --url "tcp://localhost:9999"
               Tuesday, 2017-11-21T21:48:04
               $ python3 htdatetime.py -d /dev/ttyUSB1 -b 9600 "2008-09-03T20:56:35"
               Wednesday, 2008-09-03T20:56:35
@@ -91,6 +95,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -130,6 +141,14 @@ def main() -> None:
         "if not specified current date and time on the heat pump will be returned",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -139,8 +158,18 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htfastquery_async.py
+++ b/htheatpump/scripts/htfastquery_async.py
@@ -25,6 +25,9 @@
     .. code-block:: shell
 
        $ python3 htfastquery_async.py --device /dev/ttyUSB1 "Temp. Vorlauf" "Temp. Ruecklauf"
+       or
+       $ python3 htfastquery_async.py --device /dev/ttyUSB1 "Temp. Vorlauf" "Temp. Ruecklauf"
+
        Temp. Ruecklauf [MP,04]: 25.2
        Temp. Vorlauf   [MP,03]: 25.3
 
@@ -61,6 +64,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htfastquery_async.py --device /dev/ttyUSB1 "Temp. Vorlauf" "Temp. Ruecklauf"
+              or
+              $ python3 htfastquery_async.py --device /dev/ttyUSB1 "Temp. Vorlauf" "Temp. Ruecklauf"
               Temp. Ruecklauf [MP,04]: 25.2
               Temp. Vorlauf   [MP,03]: 25.3
             """
@@ -82,6 +87,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -131,6 +143,14 @@ async def main_async() -> None:
         "all known parameters representing a MP data point",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -140,8 +160,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -189,7 +219,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htfaultlist.py
+++ b/htheatpump/scripts/htfaultlist.py
@@ -63,6 +63,8 @@ def main() -> None:
             Example:
 
               $ python3 htfaultlist.py --device /dev/ttyUSB1
+              or
+              $ python3 htfaultlist.py --url "tcp://localhost:9999"
               #000 [2000-01-01T00:00:00]: 65534, Keine Stoerung
               #001 [2000-01-01T00:00:00]: 65286, Info: Programmupdate 1
               #002 [2000-01-01T00:00:00]: 65285, Info: Initialisiert
@@ -87,6 +89,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -137,6 +146,14 @@ def main() -> None:
         "index", type=int, nargs="*", help="fault list index/indices to query for"
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -146,8 +163,17 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htfaultlist_async.py
+++ b/htheatpump/scripts/htfaultlist_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htfaultlist_async.py --device /dev/ttyUSB1 --baudrate 9600
+       or
+       $ python3 htfaultlist_async.py --url "tcp://localhost:9999"
        #000 [2000-01-01T00:00:00]: 65534, Keine Stoerung
        #001 [2000-01-01T00:00:00]: 65286, Info: Programmupdate 1
        #002 [2000-01-01T00:00:00]: 65285, Info: Initialisiert
@@ -64,6 +66,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htfaultlist_async.py --device /dev/ttyUSB1
+              or
+              $ python3 htfaultlist_async.py --url "tcp://localhost:9999"
               #000 [2000-01-01T00:00:00]: 65534, Keine Stoerung
               #001 [2000-01-01T00:00:00]: 65286, Info: Programmupdate 1
               #002 [2000-01-01T00:00:00]: 65285, Info: Initialisiert
@@ -88,6 +92,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -138,6 +149,14 @@ async def main_async() -> None:
         "index", type=int, nargs="*", help="fault list index/indices to query for"
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -147,8 +166,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -214,7 +243,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/hthttp.py
+++ b/htheatpump/scripts/hthttp.py
@@ -47,6 +47,8 @@
     .. code-block:: shell
 
        $ python3 hthttp.py start --device /dev/ttyUSB1 --ip 192.168.11.91 --port 8081
+       or
+       $ python3 hthttp.py start --url "tcp://localhost:9999" --ip 192.168.11.91 --port 8081
        hthttp.py started with PID 1099
 
        $ tail /tmp/hthttp-daemon.log
@@ -286,7 +288,17 @@ class HtHttpDaemon(Daemon):
         _LOGGER.info("=== HtHttpDaemon.run() %s", "=" * 100)
         try:
             global hp
-            hp = HtHeatpump(args.device, baudrate=args.baudrate)
+
+            if (args.url):
+                # Use keyword argument 'url'
+                hp = HtHeatpump(url=args.url, timeout=args.timeout)
+                if args.verbose:
+                    _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+            else:
+                # Use keyword argument 'device' and pass serial-specific options
+                hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+                if args.verbose:
+                    _LOGGER.info("--device specified, using serial connection: %s", args.device)
             hp.open_connection()
             hp.login()
             rid = hp.get_serial_number()
@@ -340,6 +352,8 @@ def main() -> None:
             Example:
 
               $ python3 hthttp.py start --device /dev/ttyUSB1 --ip 192.168.11.91 --port 8081
+              or
+              $ python3 hthttp.py start --url "tcp://localhost:9999" --ip 192.168.11.91 --port 8081
               hthttp.py started with PID 1099
 
               $ tail /tmp/hthttp-daemon.log
@@ -365,6 +379,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -419,6 +440,14 @@ def main() -> None:
         "--verbose",
         action="store_true",
         help="increase output verbosity by activating logging",
+    )
+
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
     )
 
     global args

--- a/htheatpump/scripts/htquery.py
+++ b/htheatpump/scripts/htquery.py
@@ -32,6 +32,12 @@
            "Stoerung": false,
            "Temp. Aussen": 3.2
        }
+
+       $ python3 htquery.py --url "tcp://hostname:port" "Temp. Aussen" "Stoerung"
+       {
+           "Stoerung": false,
+           "Temp. Aussen": 3.2
+       }
 """
 
 import argparse
@@ -58,6 +64,8 @@ def main() -> None:
             Example:
 
               $ python3 htquery.py --device /dev/ttyUSB1 "Temp. Aussen" "Stoerung"
+              or
+              $ python3 htquery.py --url "tcp://192.168.1.2:9999" "Temp. Aussen" "Stoerung"
               Stoerung    : False
               Temp. Aussen: 5.0
             """
@@ -79,6 +87,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -127,6 +142,14 @@ def main() -> None:
         help="parameter name(s) to query for (as defined in htparams.csv) or omit to query for all known parameters",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -136,8 +159,18 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htquery_async.py
+++ b/htheatpump/scripts/htquery_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htquery_async.py --device /dev/ttyUSB1 "Temp. Aussen" "Stoerung"
+       or
+       $ python3 htquery.py --url "tcp://192.168.1.2:9999" "Temp. Aussen" "Stoerung"
        Stoerung    : False
        Temp. Aussen: 5.0
 
@@ -57,8 +59,9 @@ async def main_async() -> None:
             Command line tool to query for parameters of the Heliotherm heat pump.
 
             Example:
-
               $ python3 htquery_async.py --device /dev/ttyUSB1 "Temp. Aussen" "Stoerung"
+              or
+              $ python3 htquery.py --url "tcp://192.168.1.2:9999" "Temp. Aussen" "Stoerung"
               Stoerung    : False
               Temp. Aussen: 5.0
             """
@@ -80,6 +83,11 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u", "--url", type=str,
+        help="the TCP URL (e.g., tcp://192.168.1.100:9999) at which the heatpump is reachable. Provide either --device or --url.",
     )
 
     parser.add_argument(
@@ -127,8 +135,16 @@ async def main_async() -> None:
         nargs="*",
         help="parameter name(s) to query for (as defined in htparams.csv) or omit to query for all known parameters",
     )
+    
+    parser.add_argument(
+        "--timeout", type=float, default=AioHtHeatpump.DEFAULT_TIMEOUT, # Use default from AioHtHeatpump
+        help="connection timeout in seconds, default: %(default)s",
+    )
 
     args = parser.parse_args()
+
+    if not args.device and not args.url:
+        parser.error("Either --device or --url must be specified.")
 
     # activate logging with level DEBUG in verbose mode
     log_format = "%(asctime)s %(levelname)s [%(name)s|%(funcName)s]: %(message)s"
@@ -137,8 +153,14 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if args.url:
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose: _LOGGER.info("Using TCP connection: %s", args.url)
+        else: # args.device must be set
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose: _LOGGER.info("Using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -182,7 +204,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htset.py
+++ b/htheatpump/scripts/htset.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htset.py --device /dev/ttyUSB1 "HKR Soll_Raum" "21.5"
+       or
+       $ python3 htset.py --url "tcp://localhost:9999" "HKR Soll_Raum" "21.5" 
        21.5
 """
 
@@ -58,6 +60,8 @@ def main() -> None:
             Example:
 
               $ python3 htset.py --device /dev/ttyUSB1 "HKR Soll_Raum" "21.5"
+              or
+              $ python3 htset.py --url "tcp://localhost:9999" "HKR Soll_Raum" "21.5"
               21.5
             """
         ),
@@ -78,6 +82,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -117,6 +128,14 @@ def main() -> None:
         help="parameter name (as defined in htparams.csv)",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     parser.add_argument("value", type=str, nargs=1, help="parameter value (as string)")
 
     args = parser.parse_args()
@@ -128,8 +147,17 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htset_async.py
+++ b/htheatpump/scripts/htset_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htset_async.py --device /dev/ttyUSB1 "HKR Soll_Raum" "21.5"
+       or
+       $ python3 htset_async.py --url "tcp://localhost:9999" "HKR Soll_Raum" "21.5"
        21.5
 """
 
@@ -59,6 +61,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htset_async.py --device /dev/ttyUSB1 "HKR Soll_Raum" "21.5"
+              or
+              $ python3 htset.py --url "tcp://localhost:9999" "HKR Soll_Raum" "21.5"
               21.5
             """
         ),
@@ -79,6 +83,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -118,6 +129,14 @@ async def main_async() -> None:
         help="parameter name (as defined in htparams.csv)",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     parser.add_argument("value", type=str, nargs=1, help="parameter value (as string)")
 
     args = parser.parse_args()
@@ -129,8 +148,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -160,7 +189,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htshell.py
+++ b/htheatpump/scripts/htshell.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htshell.py --device /dev/ttyUSB1 --baudrate 9600 "AR,28,29,30" -r 3
+       or
+       $ python3 htshell.py --url "tcp://localhost:9999" "AR,28,29,30" -r 3
        > 'AR,28,29,30'
        < 'AA,28,19,14.09.14-02:08:56,EQ_Spreizung'
        < 'AA,29,20,14.09.14-11:52:08,EQ_Spreizung'
@@ -56,6 +58,8 @@ def main() -> None:
             Example:
 
               $ python3 htshell.py --device /dev/ttyUSB1 "AR,28,29,30" -r 3
+              or
+              $ python3 htshell.py --url "tcp://localhost:9999" "AR,28,29,30" -r 3
               > 'AR,28,29,30'
               < 'AA,28,19,14.09.14-02:08:56,EQ_Spreizung'
               < 'AA,29,20,14.09.14-11:52:08,EQ_Spreizung'
@@ -79,6 +83,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -125,6 +136,14 @@ def main() -> None:
         help="command(s) to send to the heat pump (without the preceding '~' and the trailing ';')",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -134,8 +153,17 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htshell_async.py
+++ b/htheatpump/scripts/htshell_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htshell_async.py --device /dev/ttyUSB1 --baudrate 9600 "AR,28,29,30" -r 3
+       or
+       $ python3 htshell_async.py --url "tcp://localhost:9999" "AR,28,29,30" -r 3
        > 'AR,28,29,30'
        < 'AA,28,19,14.09.14-02:08:56,EQ_Spreizung'
        < 'AA,29,20,14.09.14-11:52:08,EQ_Spreizung'
@@ -57,6 +59,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htshell_async.py --device /dev/ttyUSB1 "AR,28,29,30" -r 3
+              or
+              $ python3 htshell_async.py --url "tcp://localhost:9999" "AR,28,29,30" -r 3
               > 'AR,28,29,30'
               < 'AA,28,19,14.09.14-02:08:56,EQ_Spreizung'
               < 'AA,29,20,14.09.14-11:52:08,EQ_Spreizung'
@@ -80,6 +84,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -126,6 +137,14 @@ async def main_async() -> None:
         help="command(s) to send to the heat pump (without the preceding '~' and the trailing ';')",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -135,8 +154,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -169,7 +198,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/httimeprog.py
+++ b/htheatpump/scripts/httimeprog.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 httimeprog.py --device /dev/ttyUSB1 --baudrate 9600
+       or
+       $ python3 httimeprog.py --url "tcp://localhost:9999"
        idx=0, name='Warmwasser', ead=7, nos=2, ste=15, nod=7, entries=[]
        idx=1, name='Zirkulationspumpe', ead=7, nos=2, ste=15, nod=7, entries=[]
        idx=2, name='Heizung', ead=7, nos=3, ste=15, nod=7, entries=[]
@@ -55,6 +57,8 @@ def main() -> None:
             Example:
 
               $ python3 httimeprog.py --device /dev/ttyUSB1 --baudrate 9600
+              or
+              $ python3 httimeprog.py --url "tcp://localhost:9999"
               idx=0, name='Warmwasser', ead=7, nos=2, ste=15, nod=7, entries=[]
               idx=1, name='Zirkulationspumpe', ead=7, nos=2, ste=15, nod=7, entries=[]
               idx=2, name='Heizung', ead=7, nos=3, ste=15, nod=7, entries=[]
@@ -79,6 +83,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -145,6 +156,14 @@ def main() -> None:
         help="number of entry of a specific day of a time program to query for",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -154,8 +173,17 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/httimeprog_async.py
+++ b/htheatpump/scripts/httimeprog_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 httimeprog_async.py --device /dev/ttyUSB1 --baudrate 9600
+       or
+       $ python3 httimeprog_async.py --url "tcp://localhost:9999"
        idx=0, name='Warmwasser', ead=7, nos=2, ste=15, nod=7, entries=[]
        idx=1, name='Zirkulationspumpe', ead=7, nos=2, ste=15, nod=7, entries=[]
        idx=2, name='Heizung', ead=7, nos=3, ste=15, nod=7, entries=[]
@@ -56,6 +58,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 httimeprog_async.py --device /dev/ttyUSB1 --baudrate 9600
+              or
+              $ python3 httimeprog_async.py --url "tcp://localhost:9999"
               idx=0, name='Warmwasser', ead=7, nos=2, ste=15, nod=7, entries=[]
               idx=1, name='Zirkulationspumpe', ead=7, nos=2, ste=15, nod=7, entries=[]
               idx=2, name='Heizung', ead=7, nos=3, ste=15, nod=7, entries=[]
@@ -80,6 +84,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -146,6 +157,14 @@ async def main_async() -> None:
         help="number of entry of a specific day of a time program to query for",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -155,8 +174,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout) # Pass timeout if needed
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -307,7 +336,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 


### PR DESCRIPTION
Port TCP socket support from dstrigl's socket-connection branch to latest master for both sync and async versions of htheatpump.

Introduced support in all scripts to handle "--url tcp://host:port" and optionally "--timeout n" parameters.

Especially some parts of aioheatpump.py have been retouched with help of Gemini, for better async handling.

Tested with example commands from each script.