### PR TITLE
Add TCP socket support, CLI upgrades, and test coverage

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,5 +16,6 @@ Thanks to
 * Alois,
 * Simon and
 * Felix (`FelixPetriconi <https://github.com/FelixPetriconi>`_)
+* Silviu (`Silviu <https://github.com/silviuk>`_)
 
 for their contribution with testing the functionality of this module.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+1.3.4 (2025-04-21)
+------------------
+* ported support for connecting to the heat pump serial port over a TCP socket
+
 1.3.3 (2023-??-??)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Introduction
 
 This library provides a pure Python interface to access `Heliotherm <http://www.heliotherm.com/>`_ and
 `Brötje BSW NEO <https://www.broetje.de/>`_ heat pumps
-over a serial connection. It's compatible with Python version 3.8, 3.9 and 3.10.
+over a serial connection or over a TCP socket. It's compatible with Python version 3.8, 3.9 and 3.10.
 
 
 Features
@@ -70,7 +70,7 @@ Tested with [*]_
 * Heliotherm HP-30-L-M-WEB, SW 3.0.21
 * Brötje BSW NEO 8 SW 3.0.38
 
-  .. [*] thanks to Kilian, Hans, Alois, Simon, Felix (`FelixPetriconi <https://github.com/FelixPetriconi>`_) and Matthias for contribution
+  .. [*] thanks to Kilian, Hans, Alois, Simon, Felix (`FelixPetriconi <https://github.com/FelixPetriconi>`_), Matthias and Silviu (`Silviu <https://github.com/silviuk>`_) for contribution
 
 
 Installation
@@ -98,11 +98,17 @@ To use ``htheatpump`` in a project take a look on the following example. After e
 with the Heliotherm heat pump one can interact with it by different functions like reading or writing
 parameters.
 
+The following examples assume a serial connection, with equivalent code TCP connections given as a comment.
+
 .. code:: python
 
     from htheatpump import HtHeatpump
 
+    # Serial connection
     hp = HtHeatpump("/dev/ttyUSB0", baudrate=9600)
+    # or serial-over-TCP connection
+    hp = HtHeatpump(url="tcp://192.168.1.100:9999")
+    
     try:
         hp.open_connection()
         hp.login()
@@ -118,7 +124,11 @@ parameters.
 
     from htheatpump import AioHtHeatpump
 
+    # Serial connection
     hp = AioHtHeatpump("/dev/ttyUSB0", baudrate=9600)
+    # or TCP connection
+    hp = AioHtHeatpump(url="tcp://192.168.1.100:9999")
+    
     try:
         hp.open_connection()
         await hp.login_async()
@@ -139,6 +149,11 @@ can be run immediately after installation, e.g.:
 .. code-block:: shell
 
     $ htquery --device /dev/ttyUSB1 "Temp. Aussen" "Stoerung"
+    # $ htquery --url "tcp://192.168.1.2:9999" "Temp. Aussen" "Stoerung" # for TCP connection
+    Stoerung    : False
+    Temp. Aussen: 5.0
+
+    $ htquery --url "tcp://192.168.1.100:9999" "Temp. Aussen" "Stoerung"
     Stoerung    : False
     Temp. Aussen: 5.0
 

--- a/htheatpump/__version__.py
+++ b/htheatpump/__version__.py
@@ -19,4 +19,4 @@
 
 from typing import Final
 
-__version__: Final = "1.3.2"
+__version__: Final = "1.3.4"

--- a/htheatpump/aiohtheatpump.py
+++ b/htheatpump/aiohtheatpump.py
@@ -27,8 +27,9 @@ import datetime
 import logging
 import re
 from typing import Dict, Final, List, Optional, Set, Tuple, Union, cast
-
+import socket
 import aioserial
+import time
 import serial
 
 from .htheatpump import HtHeatpump, VerifyAction
@@ -83,6 +84,8 @@ _LOGGER: Final = logging.getLogger(__name__)
 class AioHtHeatpump(HtHeatpump):
     """Object which encapsulates the asynchronous communication with the Heliotherm heat pump.
 
+    :param url: The TCP URL (e.g., tcp://192.168.1.100:9999). Provide either device or url.
+    :type url: Optional[str]
     :param device: The serial device to attach to (e.g. :data:`/dev/ttyUSB0`).
     :type device: str
     :param baudrate: The baud rate to use for the serial device.
@@ -94,7 +97,7 @@ class AioHtHeatpump(HtHeatpump):
     :param stopbits: The number of stop bits to use.
     :type stopbits: float or int
     :param timeout: The read timeout value.
-        Default is :attr:`~htheatpump.htheatpump.HtHeatpump.DEFAULT_SERIAL_TIMEOUT`.
+        Default is :attr:`~htheatpump.htheatpump.HtHeatpump.DEFAULT_TIMEOUT`.
     :type timeout: None, float or int
     :param xonxoff: Software flow control enabled.
     :type xonxoff: bool
@@ -121,27 +124,37 @@ class AioHtHeatpump(HtHeatpump):
 
     Example::
 
-        hp = AioHtHeatpump("/dev/ttyUSB0", baudrate=9600)
-        try:
-            hp.open_connection()
-            await hp.login_async()
-            # query for the outdoor temperature
-            temp = await hp.get_param_async("Temp. Aussen")
-            print(temp)
-            # ...
-        finally:
-            await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-            hp.close_connection()
+        # Serial
+        hp = AioHtHeatpump(device="/dev/ttyUSB0", baudrate=9600)
+        # TCP
+        hp = AioHtHeatpump(url="tcp://192.168.1.100:9999")
+
+        async def run():
+            try:
+                # open_connection is synchronous (prepares settings)
+                hp.open_connection()
+                # login_async establishes connection and logs in
+                await hp.login_async()
+                temp = await hp.get_param_async("Temp. Aussen")
+                print(temp)
+                # ...
+            finally:
+                # logout_async also closes the connection
+                await hp.logout_async()
+
     """
+
+    _ser: Optional[aioserial.AioSerial]
 
     def __init__(
         self,
-        device: str,
+        device: Optional[str] = None,  # Changed: Make optional
+        url: Optional[str] = None,    # Added: url parameter
         baudrate: int = 115200,
         bytesize: int = serial.EIGHTBITS,
         parity: str = serial.PARITY_NONE,
         stopbits: Union[float, int] = serial.STOPBITS_ONE,
-        timeout: Optional[Union[float, int]] = HtHeatpump.DEFAULT_SERIAL_TIMEOUT,
+        timeout: Optional[Union[float, int]] = HtHeatpump.DEFAULT_TIMEOUT,
         xonxoff: bool = True,
         rtscts: bool = False,
         write_timeout: Optional[Union[float, int]] = None,
@@ -156,7 +169,11 @@ class AioHtHeatpump(HtHeatpump):
     ) -> None:
         """Initialize the AioHtHeatpump class."""
 
+        if (device is None and url is None) or (device is not None and url is not None):
+            raise ValueError("Exactly one of 'device' or 'url' must be provided.")
+
         super().__init__(
+            url,
             device,
             baudrate,
             bytesize,
@@ -172,45 +189,288 @@ class AioHtHeatpump(HtHeatpump):
             verify_param_action,
             verify_param_error,
         )
-        # update the settings for later connection establishment
-        self._ser_settings.update(
-            {
-                "loop": loop,
-                "cancel_read_timeout": cancel_read_timeout,
-                "cancel_write_timeout": cancel_write_timeout,
-            }
-        )
+
+        # Async specific attributes
+        self._loop = loop  # Store loop, might be None initially
         self._lock = asyncio.Lock()
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        # _ser (aioserial instance) is handled below
+
+        # Initialize settings if not present (parent class might not set them)
+        if not hasattr(self, "_ser_settings"):
+            self._ser_settings = None
+        if not hasattr(self, "_sock_settings"):
+            self._sock_settings = None
+
+        if device and self._ser_settings is None:
+            self._ser_settings = {
+                "port": device,
+                "baudrate": baudrate,
+                "bytesize": bytesize,
+                "parity": parity,
+                "stopbits": stopbits,
+                "timeout": timeout,
+                "xonxoff": xonxoff,
+                "rtscts": rtscts,
+                "write_timeout": write_timeout,
+                "dsrdtr": dsrdtr,
+                "inter_byte_timeout": inter_byte_timeout,
+                "exclusive": exclusive,
+            }
+
+        if url and self._sock_settings is None:
+            # Parse URL (e.g. tcp://192.168.1.100:9999)
+            _url = url
+            if _url.startswith("tcp://"):
+                _url = _url[6:]
+            host, port = _url.split(":")
+            self._sock_settings = {
+                "address": (host, int(port)),
+                "timeout": timeout,
+            }
+
+        # update the settings for later connection establishment
+        if self._ser_settings:
+            self._ser_settings.update(
+                {
+                    "loop": self._loop,
+                    "cancel_read_timeout": cancel_read_timeout,
+                    "cancel_write_timeout": cancel_write_timeout,
+                }
+            )
+        self._ser = None
+
+        # _sock_settings is populated by parent __init__ if url was provided
+
+    # --- Connection Management ---
 
     def open_connection(self) -> None:
         """Open the serial connection with the defined settings.
 
-        :raises IOError:
-            When the serial connection is already open.
-        :raises ValueError:
-            Will be raised when parameter are out of range, e.g. baudrate, bytesize.
-        :raises SerialException:
-            In case the device can not be found or can not be configured.
+        :raises IOError: If the connection objects indicate it's already open.
+        :raises RuntimeError: If neither serial nor TCP is configured.
         """
-        if self._ser:
-            raise IOError("serial connection already open")
-        # open the serial connection (must fit with the settings on the heat pump!)
-        self._ser = aioserial.AioSerial(**self._ser_settings)
-        _LOGGER.info(self._ser)  # log serial connection properties
+        if self.is_open:
+            raise IOError("connection objects indicate an open connection.")
+
+        # Reset async state variables
+        self._reader = None
+        self._writer = None
+        # Re-initialize aioserial instance if needed (settings might have changed)
+        if self._ser_settings:
+            if self._ser and self._ser.is_open:
+                self._ser.close()  # Close existing if open
+            # Ensure loop is available
+            if self._loop is None:
+                try:
+                    self._loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    self._loop = None
+            # Update loop in settings if it was None before
+            self._ser_settings["loop"] = self._loop
+            self._ser = aioserial.AioSerial(**self._ser_settings)
+            _LOGGER.info("prepared serial connection: %s", self._ser)
+        elif self._sock_settings:
+            _LOGGER.info("prepared TCP connection settings: %s", self._sock_settings)
+        else:
+            raise RuntimeError("neither serial nor socket settings are configured.")
+
+    async def connect_async(self) -> None:
+        """Establishes the asynchronous connection (Serial or TCP)."""
+        if self.is_open:
+            _LOGGER.debug("connection already open, skipping connect_async.")
+            return
+
+        if self._ser_settings:
+            if not self._ser:
+                raise RuntimeError("serial instance not prepared. Call open_connection first.")
+            if not self._ser.is_open:
+                try:
+                    # aioserial opens implicitly, but let's ensure it
+                    # A simple check or triggering an operation might be needed
+                    # Forcing open if possible, or relying on first IO
+                    # Let's try to trigger opening via a zero-byte read
+                    await self._ser.read_async(0)
+                    _LOGGER.info("serial connection confirmed open: %s", self._ser)
+                except (aioserial.SerialException, OSError) as e:
+                    _LOGGER.error("failed to open serial connection %s: %s", self._ser.port, e)
+                    raise IOError(f"failed to open serial connection {self._ser.port}: {e}") from e
+
+        elif self._sock_settings:
+            address = cast(Tuple[Optional[str], int], self._sock_settings["address"])
+            host, port = address
+            # Use timeout from settings, fallback to default
+            timeout = cast(Optional[float], self._sock_settings.get("timeout"))
+            if timeout is None:
+                timeout = self.DEFAULT_TIMEOUT
+
+            try:
+                _LOGGER.debug("attempting to open TCP connection to %s:%s with timeout %s", host, port, timeout)
+                self._reader, self._writer = await asyncio.wait_for(
+                    asyncio.open_connection(host, port),
+                    timeout=timeout
+                )
+                _LOGGER.info("TCP connection established successfully to %s:%s", host, port)
+            except asyncio.TimeoutError:
+                _LOGGER.error("TCP connection timed out to %s:%s", host, port)
+                raise IOError(f"TCP connection timed out to {host}:{port}") from None
+            except (socket.gaierror, ConnectionRefusedError, OSError) as e:
+                _LOGGER.error("TCP connection failed to %s:%s: %s", host, port, e)
+                # Close potentially partially opened streams on failure
+                if self._writer:
+                    self._writer.close()
+                    # await self._writer.wait_closed() # Might hang if connection failed badly
+                self._reader = None
+                self._writer = None
+                raise IOError(f"TCP connection failed to {host}:{port}: {e}") from e
+        else:
+            raise RuntimeError("neither serial nor socket settings are configured.")
+
+    async def close_connection_async(self) -> None:
+        """Close the established asynchronous connection."""
+        if self._ser_settings:
+            if self._ser and self._ser.is_open:
+                try:
+                    self._ser.close()
+                    _LOGGER.info("serial connection closed.")
+                except Exception as e:
+                    _LOGGER.warning("error closing serial connection: %s", e)
+                finally:
+                    self._ser = None  # Ensure instance is cleared
+                    await asyncio.sleep(0.1)  # Keep delay
+        elif self._sock_settings:
+            if self._writer:
+                try:
+                    if not self._writer.is_closing():
+                        self._writer.close()
+                        await self._writer.wait_closed()
+                        _LOGGER.info("TCP connection closed.")
+                    else:
+                        _LOGGER.debug("TCP writer already closing.")
+                except Exception as e:
+                    _LOGGER.warning("error closing TCP writer: %s", e)
+                finally:
+                    self._writer = None  # Ensure cleared
+                    self._reader = None  # Ensure cleared
+                    await asyncio.sleep(0.1)  # Keep delay
+
+        # Ensure state is reset even if already closed or error occurred
+        self._ser = None
+        self._reader = None
+        self._writer = None
+
+    def close_connection(self) -> None:
+        """Close the connection (Synchronous wrapper - Use with caution)."""
+        if self.is_open:
+            _LOGGER.warning("close_connection called synchronously on AioHtHeatpump. Use close_connection_async.")
+            # Try sync close for serial if possible
+            if self._ser and self._ser.is_open:
+                try:
+                    self._ser.close()
+                    time.sleep(0.1)
+                except Exception as e:
+                    _LOGGER.error("synchronous close of aioserial failed: %s", e)
+            elif self._writer:
+                _LOGGER.error("cannot synchronously close active async TCP connection. Use close_connection_async.")
+            # Reset state regardless
+            self._ser = None
+            self._reader = None
+            self._writer = None
+        else:
+            # Ensure state is reset if called when not open
+            self._ser = None
+            self._reader = None
+            self._writer = None
+
+    async def reconnect_async(self) -> None:
+        """Reconnect asynchronously (close, prepare, connect)."""
+        _LOGGER.info("attempting to reconnect...")
+        await self.close_connection_async()
+        # open_connection is sync and just prepares settings/instances
+        self.open_connection()
+        # connect_async actually establishes the connection
+        await self.connect_async()
+        _LOGGER.info("reconnection attempt finished.")
+
+    def reconnect(self) -> None:
+        """Synchronous reconnect wrapper (Not Recommended)."""
+        _LOGGER.warning("reconnect called synchronously on AioHtHeatpump. Use reconnect_async.")
+        raise NotImplementedError("synchronous reconnect is not supported. Use reconnect_async.")
+
+    @property
+    def is_open(self) -> bool:
+        """Return the state of the asynchronous connection."""
+        if self._ser_settings:
+            # Check aioserial instance and its state
+            return self._ser is not None and self._ser.is_open
+        elif self._sock_settings:
+            # Check if writer exists and is not closing/closed, and reader is not EOF
+            return (
+                self._writer is not None
+                and not self._writer.is_closing()
+                and self._reader is not None
+                and not self._reader.at_eof()
+            )
+        return False
+
+    # --- Communication Methods ---
 
     async def send_request_async(self, cmd: str) -> None:
-        """Send a request to the heat pump.
+        """Send a request asynchronously to the heat pump."""
+        if not self.is_open:
+            # Try to connect if not open? Or raise error? Raising is safer.
+            raise IOError("connection not open")
 
-        :param cmd: Command to send to the heat pump.
-        :type cmd: str
-        :raises IOError:
-            Will be raised when the serial connection is not open.
-        """
-        if not self._ser:
-            raise IOError("serial connection not open")
         req = create_request(cmd)
-        _LOGGER.debug("send request: [%s]", req)
-        await self._ser.write_async(req)
+        _LOGGER.debug("send async request: [%s]", req)
+
+        try:
+            if self._ser_settings:
+                if not self._ser:
+                    raise IOError("serial connection not initialized")
+                await self._ser.write_async(req)
+                # await self._ser.drain_async() # Usually not needed for serial
+            elif self._sock_settings:
+                if not self._writer:
+                    raise IOError("TCP connection not established")
+                self._writer.write(req)
+                await self._writer.drain()  # Ensure data is sent over TCP
+            else:
+                # This case should be prevented by __init__
+                raise RuntimeError("neither serial, nor socket settings are configured")
+        except (aioserial.SerialException, socket.error, OSError, BrokenPipeError) as e:
+            _LOGGER.error("Failed to send async request: %s", e)
+            # Connection likely broken, close it
+            await self.close_connection_async()
+            raise IOError(f"failed to send async request: {e}") from e
+
+    async def _socket_recvall_async(self, size: int) -> bytes:
+        """Receive exactly size bytes asynchronously from TCP socket."""
+        if not self._reader:
+            raise IOError("TCP connection not established or reader is missing")
+
+        # Use timeout from settings for the read operation
+        timeout = cast(Optional[float], self._sock_settings.get("timeout")) if self._sock_settings else None
+        if timeout is None:
+            timeout = self.DEFAULT_TIMEOUT
+
+        try:
+            data = await asyncio.wait_for(self._reader.readexactly(size), timeout=timeout)
+            return data
+        except asyncio.TimeoutError:
+            _LOGGER.error("socket read timed out waiting for %d bytes", size)
+            await self.close_connection_async()
+            raise IOError(f"socket read timed out waiting for {size} bytes") from None
+        except asyncio.IncompleteReadError as e:
+            _LOGGER.error("socket connection closed or broke during readexactly "
+                          "(expected %d, got %d)", size, len(e.partial))
+            await self.close_connection_async()
+            raise IOError("socket connection closed or broke during read") from e
+        except (socket.error, OSError) as e:
+            _LOGGER.error("socket error during readexactly: %s", e)
+            await self.close_connection_async()
+            raise IOError(f"socket error during read: {e}") from e
 
     async def read_response_async(self) -> str:
         """Read the response message from the heat pump.
@@ -246,84 +506,181 @@ class AioHtHeatpump(HtHeatpump):
             must be corrected (for the checksum computation) so that the received checksum fits with the computed
             one (e.g. for ``b"\\x02\\xfd\\xe0\\xd0\\x01\\x00"`` and ``b"\\x02\\xfd\\xe0\\xd0\\x02\\x00"``).
         """
-        if not self._ser:
-            raise IOError("serial connection not open")
-        # read the header of the response message
-        header = await self._ser.read_async(RESPONSE_HEADER_LEN)
-        if not header:
-            raise IOError("data stream broken during reading response header")
+        if not self.is_open:
+            raise IOError("connection not open")
+
+        # Determine read timeout
+        read_timeout: Optional[Union[float, int]] = None
+        if self._ser_settings:
+            read_timeout = self._ser.timeout if self._ser else self.DEFAULT_TIMEOUT
+        elif self._sock_settings:
+            read_timeout = cast(Optional[Union[float, int]], self._sock_settings.get("timeout", self.DEFAULT_TIMEOUT))
+        if read_timeout is None:
+            read_timeout = self.DEFAULT_TIMEOUT  # Ensure a value
+
+        # Read header
+        try:
+            if self._ser_settings:
+                if not self._ser:
+                    raise IOError("serial connection not initialized")
+                header = await asyncio.wait_for(self._ser.read_async(RESPONSE_HEADER_LEN), timeout=read_timeout)
+            elif self._sock_settings:
+                header = await self._socket_recvall_async(RESPONSE_HEADER_LEN)  # Uses internal timeout
+            else:
+                raise RuntimeError("neither serial, nor socket settings are configured.")
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+            _LOGGER.error("failed reading response header: %s", e)
+            await self.close_connection_async()
+            raise IOError(f"failed reading response header: {e}") from e
+
+        if not header or len(header) < RESPONSE_HEADER_LEN:
+            await self.close_connection_async()
+            raise IOError(f"data stream broken reading header (incomplete: {header!r})")
         elif header not in RESPONSE_HEADER:
-            raise IOError("invalid or unknown response header [{}]".format(header))
-        # read the length of the following payload
-        payload_len_r = await self._ser.read_async(1)
-        if not payload_len_r:
-            raise IOError("data stream broken during reading payload length")
-        payload_len = payload_len_r = payload_len_r[0]
-        # We don't know why, but for some messages (e.g. for the error message "ERR,INVALID IDX") the
-        # heat pump answers with a payload length of zero bytes. In order to also accept such responses
-        # we read until we will found the trailing "\r\n" at the end of the payload. The payload length
-        # itself will then be computed afterwards by counting the number of bytes of the payload.
-        if payload_len == 0:
-            _LOGGER.info(
-                "received response with a payload length of zero;"
-                " try to read until the occurrence of '\\r\\n' [header=%s]",
-                header,
-            )
-            payload = b""
-            while payload[-2:] != b"\r\n":
-                tmp = await self._ser.read_async(1)
-                if not tmp:
-                    raise IOError(
-                        "data stream broken during reading payload ending with '\\r\\n'"
-                    )
-                payload += tmp
-            # compute the payload length by counting the number of read bytes
-            payload_len = len(payload)
-        else:
-            # read the payload itself
-            payload = await self._ser.read_async(payload_len)
-            if not payload or len(payload) < payload_len:
-                raise IOError("data stream broken during reading payload")
-        # depending on the received header correct the payload length for the checksum computation,
-        #   so that the received checksum fits with the computed one
-        payload_len = RESPONSE_HEADER[header]["payload_len"](payload_len)
-        # read the checksum and verify the validity of the response
-        checksum = await self._ser.read_async(1)
-        if not checksum:
-            raise IOError("data stream broken during reading checksum")
-        checksum = checksum[0]
-        # compute the checksum over header, payload length and the payload itself (depending on the header)
-        comp_checksum = RESPONSE_HEADER[header]["checksum"](
-            header, payload_len, payload
+            _LOGGER.error("invalid or unknown response header received: %r", header)
+            await self.close_connection_async()
+            raise IOError(f"invalid or unknown response header [{header!r}]")
+
+        # Read payload length byte
+        try:
+            if self._ser_settings:
+                if not self._ser:
+                    raise IOError("serial connection not initialized")
+                payload_len_r_bytes = await asyncio.wait_for(self._ser.read_async(1), timeout=read_timeout)
+            else:  # Socket
+                payload_len_r_bytes = await self._socket_recvall_async(1)  # Uses internal timeout
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+            _LOGGER.error("failed reading payload length: %s", e)
+            await self.close_connection_async()
+            raise IOError(f"failed reading payload length: {e}") from e
+
+        if not payload_len_r_bytes:
+            await self.close_connection_async()
+            raise IOError("data stream broken reading payload length (empty byte)")
+
+        payload_len_r = payload_len_r_bytes[0]
+        # payload_len will be corrected later for checksum
+
+        # Read payload
+        payload: bytes
+        actual_payload_len: int
+
+        try:
+            if payload_len_r == 0:
+                _LOGGER.info("received response with a payload length zero; reading until '\\r\\n' [header=%r]", header)
+                payload = b""
+                # Use a loop with dynamic remaining timeout for each byte read
+                loop_start_time = asyncio.get_running_loop().time()
+                while payload[-2:] != b"\r\n":
+                    # Check overall timeout for this loop
+                    elapsed = asyncio.get_running_loop().time() - loop_start_time
+                    remaining_timeout = read_timeout - elapsed
+                    if remaining_timeout <= 0:
+                        raise asyncio.TimeoutError("overall timeout while reading payload ending with '\\r\\n'")
+
+                    try:
+                        if self._ser_settings:
+                            if not self._ser:
+                                raise IOError("serial connection not initialized")
+                            tmp = await asyncio.wait_for(self._ser.read_async(1), timeout=remaining_timeout)
+                        else:  # Socket
+                            tmp = await asyncio.wait_for(self._socket_recvall_async(1), timeout=remaining_timeout)
+
+                        if not tmp:
+                            raise IOError("data stream broken (received empty byte)")
+                        payload += tmp
+                    except asyncio.TimeoutError:
+                        raise asyncio.TimeoutError(
+                            "overall timeout while reading payload ending with '\\r\\n'"
+                        ) from None
+                    except (IOError, aioserial.SerialException, socket.error, OSError) as e:
+                        raise IOError(f"failed reading payload chunk (len=0): {e}") from e
+
+                actual_payload_len = len(payload)
+            else:
+                # Read payload_len_r bytes
+                if self._ser_settings:
+                    if not self._ser:
+                        raise IOError("serial connection not initialized")
+                    payload = await asyncio.wait_for(self._ser.read_async(payload_len_r), timeout=read_timeout)
+                else:  # Socket
+                    payload = await self._socket_recvall_async(payload_len_r)  # Uses internal timeout
+
+                if not payload or len(payload) < payload_len_r:
+                    raise IOError("data stream broken reading payload")
+                actual_payload_len = len(payload)
+
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+            _LOGGER.error("failed reading payload: %s", e)
+            await self.close_connection_async()
+            raise IOError(f"failed reading payload: {e}") from e
+
+        # Correct payload length for checksum computation based on header
+        # Call the function to get the corrected length value
+        corrected_payload_len_val = RESPONSE_HEADER[header]["payload_len"](payload_len_r)
+
+        # Read checksum byte
+        try:
+            if self._ser_settings:
+                if not self._ser:
+                    raise IOError("serial connection not initialized")
+                checksum_bytes = await asyncio.wait_for(self._ser.read_async(1), timeout=read_timeout)
+            else:  # Socket
+                checksum_bytes = await self._socket_recvall_async(1)  # Uses internal timeout
+        except (IOError, asyncio.TimeoutError, aioserial.SerialException, socket.error, OSError) as e:
+            _LOGGER.error("failed reading checksum: %s", e)
+            await self.close_connection_async()
+            raise IOError(f"failed reading checksum: {e}") from e
+
+        if not checksum_bytes:
+            await self.close_connection_async()
+            raise IOError("data stream broken reading checksum (empty byte)")
+        checksum = checksum_bytes[0]
+
+        # Compute and verify checksum
+        # Call the function to get the computed checksum value
+        comp_checksum_val = RESPONSE_HEADER[header]["checksum"](
+            header, corrected_payload_len_val, payload
         )
-        if checksum != comp_checksum:
-            raise IOError(
-                "invalid checksum [{}] of response "
-                "[header={}, payload_len={:d}({:d}), payload={}, checksum={}]".format(
-                    hex(checksum),
-                    header,
-                    payload_len,
-                    payload_len_r,
-                    payload,
-                    hex(comp_checksum),
-                )
+
+        # Compare the integer checksum values
+        if checksum != comp_checksum_val:
+            # Use the calculated values in the error message
+            error_msg = (
+                f"invalid checksum [{checksum:#04x}] of response "
+                f"[header={header!r}, payload_len={corrected_payload_len_val}(orig={payload_len_r}), "
+                f"payload={payload!r}, expected_checksum={comp_checksum_val:#04x}]"
             )
-        # debug log of the received response
-        _LOGGER.debug(
-            "received response: %s",
-            header + bytes([payload_len]) + payload + bytes([checksum]),
-        )
-        _LOGGER.debug("  header = %s", header)
-        _LOGGER.debug("  payload length = %d(%d)", payload_len, payload_len_r)
-        _LOGGER.debug("  payload = %s", payload)
-        _LOGGER.debug("  checksum = %s", hex(checksum))
-        # extract the relevant data from the payload (without header '~' and trailer ';\r\n')
-        m = re.match(r"^~([^;]*);\r\n$", payload.decode("ascii"))
-        if not m:
-            raise IOError(
-                "failed to extract response data from payload [{}]".format(payload)
-            )
-        return m.group(1)
+            _LOGGER.error(error_msg)
+            await self.close_connection_async()
+            raise IOError(error_msg)
+
+        # Debug log
+        _LOGGER.debug("received async response raw: %s", header + payload_len_r_bytes + payload + checksum_bytes)
+        _LOGGER.debug("  header = %r", header)
+        # Use the calculated value in the debug log
+        _LOGGER.debug("  payload length = %d (orig=%d, actual=%d)",
+                      corrected_payload_len_val, payload_len_r, actual_payload_len)
+        _LOGGER.debug("  payload = %r", payload)
+        _LOGGER.debug("  checksum = %#04x", checksum)
+
+        # Extract data
+        try:
+            decoded_payload = payload.decode("ascii")
+            m = re.match(r"^~([^;]*);\r\n$", decoded_payload)
+            if not m:
+                raise IOError(f"failed to extract response data from payload [{payload!r}]")
+            return m.group(1)
+        except UnicodeDecodeError as e:
+            _LOGGER.error("failed to decode payload as ASCII: %s [%r]", e, payload)
+            await self.close_connection_async()
+            raise IOError(f"failed to decode payload as ASCII: {e} [{payload!r}]") from e
+        except IOError as e:
+            _LOGGER.error("error extracting data: %s", e)
+            await self.close_connection_async()
+            raise e  # Re-raise the extraction error
+
+    # --- Async API Methods ---
 
     async def login_async(
         self,
@@ -347,53 +704,65 @@ class AioHtHeatpump(HtHeatpump):
             response (e.g. broken data stream, invalid checksum).
         """
         async with self._lock:
-            # we try to login the heat pump for several times
+            # Ensure connection is established before login attempt
+            await self.connect_async()  # Ensures connection is open
+
             success = False
             retry = 0
             while not success and retry <= max_retries:
-                # send LOGIN request to the heat pump
-                await self.send_request_async(LOGIN_CMD)
-                # ... and wait for the response
                 try:
+                    await self.send_request_async(LOGIN_CMD)
                     resp = await self.read_response_async()
                     m = re.match(LOGIN_RESP, resp)
                     if not m:
-                        raise IOError(
-                            "invalid response for LOGIN command [{!r}]".format(resp)
-                        )
-                    else:
-                        success = True
+                        raise IOError(f"invalid response for LOGIN command [{resp!r}]")
+                    success = True
                 except Exception as ex:
                     retry += 1
                     _LOGGER.warning("login try #%d failed: %s", retry, ex)
-                    # try a reconnect, maybe this will help ;-)
-                    self.reconnect()
+                    if retry <= max_retries:
+                        _LOGGER.info("attempting reconnect after failed login...")
+                        try:
+                            await self.reconnect_async()
+                        except Exception as recon_ex:
+                            _LOGGER.error("reconnect failed: %s", recon_ex)
+                            break  # Stop retrying if reconnect fails
+                        await asyncio.sleep(0.2 * retry)  # Slight backoff
+
             if not success:
                 _LOGGER.error("login failed after %d try/tries", retry)
-                raise IOError("login failed after {:d} try/tries".format(retry))
-            _LOGGER.info("login successfully")
-            # perform a limits update of all parameters (if desired)
+                await self.close_connection_async()  # Ensure closed on final failure
+                raise IOError(f"login failed after {retry} try/tries")
+
+            _LOGGER.info("login successful")
             if update_param_limits:
                 await self.update_param_limits_async()
 
     async def logout_async(self) -> None:
-        """Log out from the heat pump session."""
+        """Log out from the heat pump session asynchronously and close connection."""
+        if not self.is_open:
+            _LOGGER.info("connection already closed, skipping logout.")
+            return
+
+        # Use lock to prevent concurrent operations during logout/close
         async with self._lock:
+            # Check again inside lock
+            if not self.is_open:
+                _LOGGER.info("connection closed before logout could proceed.")
+                return
             try:
-                # send LOGOUT request to the heat pump
                 await self.send_request_async(LOGOUT_CMD)
-                # ... and wait for the response
                 resp = await self.read_response_async()
                 m = re.match(LOGOUT_RESP, resp)
                 if not m:
-                    raise IOError(
-                        "invalid response for LOGOUT command [{!r}]".format(resp)
-                    )
-                _LOGGER.info("logout successfully")
+                    _LOGGER.warning(f"invalid response for LOGOUT command [{resp!r}]")
+                else:
+                    _LOGGER.info("logout successful")
             except Exception as ex:
-                # just a warning, because it's possible that we can continue without any further problems
-                _LOGGER.warning("logout failed: %s", ex)
-                # raise  # logout_async() should not fail!
+                _LOGGER.warning("logout command failed: %s", ex)
+            finally:
+                # Always close the connection after attempting logout
+                await self.close_connection_async()
 
     async def get_serial_number_async(self) -> int:
         """Query for the manufacturer's serial number of the heat pump.
@@ -922,7 +1291,24 @@ class AioHtHeatpump(HtHeatpump):
     async def overwrite_param_async(
         self, name: str, val: Optional[HtParamValueType], ignore_limits: bool = False
     ) -> HtParamValueType:
-        """TODO doc
+        """Overwrite the value of a specific parameter of the heat pump.
+
+        :param name: The parameter name, e.g. :data:`"Betriebsart"`.
+        :type name: str
+        :param val: The value to overwrite with, or :const:`None` to clear.
+        :type val: bool, int, float or None
+        :param ignore_limits: Indicates if the parameter limits should be ignored or not.
+        :type ignore_limits: bool
+        :returns: Returned value of the parameter overwrite request.
+        :rtype: ``bool``, ``int`` or ``float``
+        :raises KeyError:
+            Will be raised when the parameter definition for the passed parameter is not found.
+        :raises ValueError:
+            Will be raised if the passed value is beyond the parameter limits and argument :attr:`ignore_limits`
+            is set to :const:`False`.
+        :raises IOError:
+            Will be raised when the serial connection is not open or received an incomplete/invalid
+            response (e.g. broken data stream, invalid checksum).
         """
         async with self._lock:
             # find the corresponding definition for the parameter

--- a/htheatpump/aiohtheatpump.py
+++ b/htheatpump/aiohtheatpump.py
@@ -33,7 +33,7 @@ import time
 import serial
 
 from .htheatpump import HtHeatpump, VerifyAction
-from .htparams import HtParams, HtParamValueType
+from .htparams import HtParam, HtParams, HtParamValueType
 from .httimeprog import TimeProgEntry, TimeProgram
 from .protocol import (
     ALC_CMD,
@@ -1138,7 +1138,7 @@ class AioHtHeatpump(HtHeatpump):
             assert (
                 name in HtParams
             ), "parameter definition for parameter {!r} not found".format(name)
-            param = HtParams[name]  # type: ignore
+            param: HtParam = HtParams[name]  # type: ignore
             # send command to the heat pump
             await self.send_request_async(param.cmd())
             # ... and wait for the response
@@ -1265,7 +1265,7 @@ class AioHtHeatpump(HtHeatpump):
                 raise KeyError(
                     "parameter definition for parameter {!r} not found".format(name)
                 )
-            param = HtParams[name]  # type: ignore
+            param: HtParam = HtParams[name]  # type: ignore
             # check the passed value against the defined limits (if desired)
             if not ignore_limits and not param.in_limits(val):
                 raise ValueError(
@@ -1274,8 +1274,8 @@ class AioHtHeatpump(HtHeatpump):
                     )
                 )
             # send command to the heat pump
-            val = param.to_str(val)
-            await self.send_request_async("{},VAL={}".format(param.cmd(), val))
+            val_str = param.to_str(val)
+            await self.send_request_async("{},VAL={}".format(param.cmd(), val_str))
             # ... and wait for the response
             try:
                 resp = await self.read_response_async()
@@ -1316,7 +1316,7 @@ class AioHtHeatpump(HtHeatpump):
                 raise KeyError(
                     "parameter definition for parameter {!r} not found".format(name)
                 )
-            param = HtParams[name]  # type: ignore
+            param: HtParam = HtParams[name]  # type: ignore
             # check the passed value against the defined limits (if desired)
             if not ignore_limits and not param.in_limits(val):
                 raise ValueError(
@@ -1328,8 +1328,8 @@ class AioHtHeatpump(HtHeatpump):
             if val is None:
                 await self.send_request_async("{},ORF=0".format(param.cmd()))
             else:
-                val = param.to_str(val)
-                await self.send_request_async("{},ORV={},ORF=1".format(param.cmd(), val))
+                val_str = param.to_str(val)
+                await self.send_request_async("{},ORV={},ORF=1".format(param.cmd(), val_str))
             # ... and wait for the response
             try:
                 resp = await self.read_response_async()
@@ -1434,7 +1434,7 @@ class AioHtHeatpump(HtHeatpump):
                     raise KeyError(
                         "parameter definition for parameter {!r} not found".format(name)
                     )
-                param = HtParams[name]  # type: ignore
+                param: HtParam = HtParams[name]  # type: ignore
                 if param.dp_type != "MP":
                     raise ValueError(
                         "invalid parameter {!r}; only parameters representing a 'MP' data point are allowed".format(

--- a/htheatpump/htheatpump.py
+++ b/htheatpump/htheatpump.py
@@ -28,9 +28,11 @@ import logging
 import re
 import time
 from types import TracebackType
-from typing import Final, Dict, List, Optional, Set, Tuple, Type, Union, cast
+from typing import Any, Final, Dict, List, Optional, Set, Tuple, Type, Union, cast
 
 import serial
+import socket
+from urllib.parse import urlparse
 
 from .htparams import HtParams, HtParamValueType
 from .httimeprog import TimeProgEntry, TimeProgram
@@ -102,6 +104,13 @@ class VerifyAction(enum.Enum):
         hp.verify_param_action = {VerifyAction.NAME, VerifyAction.MAX}
         temp = hp.get_param("Temp. Aussen")
         ...
+
+    or::
+
+        hp = HtHeatpump("tcp://localhost:9999")
+        hp.verify_param_action = {VerifyAction.NAME, VerifyAction.MAX}
+        temp = hp.get_param("Temp. Aussen")
+        ...
     """
 
     NAME = 1
@@ -149,6 +158,9 @@ class VerificationException(ValueError):  # pragma: no cover
 class HtHeatpump:
     """Object which encapsulates the communication with the Heliotherm heat pump.
 
+    :param url: The internet address (:data:`tcp://hostname:port`) to connect to
+        (e.g. :data:`tcp://192.168.1.2:8123`). Must include the scheme :data:`tcp`.
+    :type url: str
     :param device: The serial device to attach to (e.g. :data:`/dev/ttyUSB0`).
     :type device: str
     :param baudrate: The baud rate to use for the serial device.
@@ -159,7 +171,7 @@ class HtHeatpump:
     :type parity: str
     :param stopbits: The number of stop bits to use.
     :type stopbits: float or int
-    :param timeout: The read timeout value. Default is :attr:`DEFAULT_SERIAL_TIMEOUT`.
+    :param timeout: The read timeout value. Default is :attr:`DEFAULT_TIMEOUT`.
     :type timeout: None, float or int
     :param xonxoff: Software flow control enabled.
     :type xonxoff: bool
@@ -177,10 +189,17 @@ class HtHeatpump:
     :type verify_param_action: None or set
     :param verify_param_error: Interpretation of parameter verification failure as error enabled.
     :type verify_param_error: bool
+    _ser_settings: Optional[Dict[str, Any]]
+    _sock_settings: Optional[Dict[str, Any]]
+    _ser: Optional[serial.Serial]
+    _sock: Optional[socket.socket]
 
     Example::
 
         hp = HtHeatpump("/dev/ttyUSB0", baudrate=9600)
+        # or
+        hp = HtHeatpump("tcp://localhost:9999")
+
         try:
             hp.open_connection()
             hp.login()
@@ -193,20 +212,27 @@ class HtHeatpump:
             hp.close_connection()
     """
 
-    DEFAULT_SERIAL_TIMEOUT: Final[int] = 5
-    """Serial timeout value in seconds; normally no need to change it."""
+    _ser_settings: Optional[Dict[str, Any]]
+    _sock_settings: Optional[Dict[str, Any]]
+    _ser: Optional[serial.Serial]
+    _sock: Optional[socket.socket]
+
+    DEFAULT_TIMEOUT: Final[int] = 5
+    """Timeout value in seconds; normally no need to change it."""
 
     DEFAULT_LOGIN_RETRIES: Final[int] = 2
     """Maximum number of retries for a login attempt; 1 regular try + :const:`DEFAULT_LOGIN_RETRIES` retries."""
 
     def __init__(
+
         self,
-        device: str,
+        url: Optional[str] = None,
+        device: Optional[str] = None,
         baudrate: int = 115200,
         bytesize: int = serial.EIGHTBITS,
         parity: str = serial.PARITY_NONE,
         stopbits: Union[float, int] = serial.STOPBITS_ONE,
-        timeout: Optional[Union[float, int]] = DEFAULT_SERIAL_TIMEOUT,
+        timeout: Optional[Union[float, int]] = DEFAULT_TIMEOUT,
         xonxoff: bool = True,
         rtscts: bool = False,
         write_timeout: Optional[Union[float, int]] = None,
@@ -218,22 +244,43 @@ class HtHeatpump:
     ) -> None:
         """Initialize the HtHeatpump class."""
 
-        # store the serial settings for later connection establishment
-        self._ser_settings = {
-            "port": device,
-            "baudrate": baudrate,
-            "bytesize": bytesize,
-            "parity": parity,
-            "stopbits": stopbits,
-            "timeout": timeout,
-            "xonxoff": xonxoff,
-            "rtscts": rtscts,
-            "write_timeout": write_timeout,
-            "dsrdtr": dsrdtr,
-            "inter_byte_timeout": inter_byte_timeout,
-            "exclusive": exclusive,
-        }
+        if (device is None and url is None) or (device is not None and url is not None):
+            raise ValueError("Exactly one of 'device' or 'url' must be provided.")
+
+        self._ser_settings = None
+        self._sock_settings = None
         self._ser = None
+        self._sock = None
+
+        # store the serial settings for later connection establishment
+        if device is not None:
+            self._ser_settings = {
+                "port": device,
+                "baudrate": baudrate,
+                "bytesize": bytesize,
+                "parity": parity,
+                "stopbits": stopbits,
+                "timeout": timeout,
+                "xonxoff": xonxoff,
+                "rtscts": rtscts,
+                "write_timeout": write_timeout,
+                "dsrdtr": dsrdtr,
+                "inter_byte_timeout": inter_byte_timeout,
+                "exclusive": exclusive,
+            }
+            self._ser = None
+        else:  # url must be not None
+            assert url is not None
+            # store the socket settings for later connection establishment
+            url_components = urlparse(url)
+            if url_components.scheme != "tcp":
+                raise ValueError("invalid scheme for url, must be 'tcp' [{!r}]".format(url_components.scheme))
+            self._sock_settings = {
+                "address": (url_components.hostname, url_components.port),
+                "timeout": timeout,
+            }
+            self._sock = None
+
         # store settings for parameter verification
         self._verify_param_action = (
             {VerifyAction.NAME} if verify_param_action is None else verify_param_action
@@ -244,8 +291,18 @@ class HtHeatpump:
 
     def __del__(self) -> None:
         # close the connection if still established
-        if self._ser and self._ser.is_open:
-            self._ser.close()
+        ser_settings = getattr(self, "_ser_settings", None)
+        sock_settings = getattr(self, "_sock_settings", None)
+        if ser_settings is not None:  # Check if serial was configured
+            ser = getattr(self, "_ser", None)
+            if ser is not None and getattr(ser, "is_open", False):
+                # close the serial connection
+                ser.close()
+        elif sock_settings is not None:  # Check if socket was configured
+            sock = getattr(self, "_sock", None)
+            # close the socket connection
+            if sock is not None:
+                sock.close()
 
     def __enter__(self) -> HtHeatpump:
         self.open_connection()
@@ -260,47 +317,89 @@ class HtHeatpump:
         self.close_connection()
 
     def open_connection(self) -> None:
-        """Open the serial connection with the defined settings.
+        """Establishes the connection with the defined settings.
 
         :raises IOError:
-            When the serial connection is already open.
+            When the connection is already open.
         :raises ValueError:
-            Will be raised when parameter are out of range, e.g. baudrate, bytesize.
+            Will be raised when parameter are out of range, e.g. baudrate, bytesize, port.
         :raises SerialException:
-            In case the device can not be found or can not be configured.
+            In case the serial device can not be found or can not be configured.
         """
-        if self._ser:
-            raise IOError("serial connection already open")
-        # open the serial connection (must fit with the settings on the heat pump!)
-        self._ser = serial.Serial(**self._ser_settings)
-        _LOGGER.info(self._ser)  # log serial connection properties
+        if self._ser_settings is not None:  # Use serial
+            if self._ser:
+                raise IOError("serial connection already open")
+            # open the serial connection (must fit with the settings on the heat pump!)
+            self._ser = serial.Serial(**self._ser_settings)
+            _LOGGER.info(self._ser)  # log serial connection properties
+        elif self._sock_settings is not None:  # Use socket
+            if self._sock:
+                raise IOError("TCP connection already established")
+            # establish the connection
+            address = cast(Tuple[Optional[str], int], self._sock_settings["address"])
+            timeout = cast(Optional[float], self._sock_settings.get("timeout"))
+            self._sock = socket.create_connection(address, timeout=timeout)
+            _LOGGER.info(self._sock)  # log connection properties
+        else:
+            # This should not happen due to the check in __init__
+            raise RuntimeError("Neither serial nor socket settings are configured.")
 
     def reconnect(self) -> None:
-        """Perform a reconnect of the serial connection. Flush the output and
-        input buffer, close the serial connection and open it again.
-        """
-        if self._ser and self._ser.is_open:
-            self._ser.reset_output_buffer()
-            self._ser.reset_input_buffer()
-            self.close_connection()
-        self.open_connection()
+        """Reconnect to the heat pump."""
+        if self._ser_settings is not None:  # Use serial
+            """If serial, perform a reconnect of the serial connection. Flush the output and
+            input buffer, close the serial connection and open it again.
+            """
+            if self._ser and self._ser.is_open:
+                self._ser.reset_output_buffer()
+                self._ser.reset_input_buffer()
+                self.close_connection()
+            self.open_connection()
+        elif self._sock_settings is not None:  # Use socket
+            if self._sock:
+                self.close_connection()
+            self.open_connection()
 
     def close_connection(self) -> None:
-        """Close the serial connection."""
-        if self._ser and self._ser.is_open:
-            self._ser.close()
-            self._ser = None
-            # we wait for 100ms, as it should be avoided to reopen the connection to fast
-            time.sleep(0.1)
+        if self._ser_settings is not None:  # Use serial
+            """Close the serial connection."""
+            if self._ser and self._ser.is_open:
+                self._ser.close()
+                self._ser = None
+                # we wait for 100ms, as it should be avoided to reopen the connection to fast
+                time.sleep(0.1)
+        elif self._sock_settings is not None:  # Use socket
+            """Close the tcp connection."""
+            if self._sock:
+                self._sock.close()
+                self._sock = None
+                # we wait for 100ms, as it should be avoided to reopen the connection to fast
+                time.sleep(0.1)
 
     @property
     def is_open(self) -> bool:
-        """Return the state of the serial port, whether it’s open or not.
+        """Return the state of the connection, whether it’s established or not.
 
-        :returns: The state of the serial port as :obj:`bool`.
+        :returns: The state of the connection as :obj:`bool`.
         :rtype: ``bool``
         """
-        return self._ser is not None and self._ser.is_open
+        if self._ser_settings is not None:  # Use serial
+            return self._ser is not None and self._ser.is_open
+        elif self._sock_settings is not None:  # Use socket
+            if self._sock is None:
+                return False
+            self._sock.setblocking(False)
+            try:
+                # try to read bytes without blocking and also without removing them from buffer (peek only)
+                data = self._sock.recv(16, socket.MSG_PEEK)
+                return len(data) > 0
+            except BlockingIOError:
+                return True  # socket is open and reading from it would block
+            except OSError:
+                return False  # socket was closed or has some other error
+            finally:
+                self._sock.setblocking(True)
+        return False
 
     @property
     def verify_param_action(self) -> Set[VerifyAction]:
@@ -346,13 +445,45 @@ class HtHeatpump:
         :param cmd: Command to send to the heat pump.
         :type cmd: str
         :raises IOError:
-            Will be raised when the serial connection is not open.
+            Will be raised when the connection is not established.
         """
-        if not self._ser:
-            raise IOError("serial connection not open")
-        req = create_request(cmd)
-        _LOGGER.debug("send request: [%s]", req)
-        self._ser.write(req)
+        if self._ser_settings is not None:  # Use serial
+            if not self._ser:
+                raise IOError("serial connection not open")
+            req = create_request(cmd)
+            _LOGGER.debug("send request: [%s]", req)
+            self._ser.write(req)
+        elif self._sock_settings is not None:  # Use socket
+            if not self._sock:
+                raise IOError("TCP connection not established")
+            req = create_request(cmd)
+            _LOGGER.debug("send request: [%s]", req)
+            try:
+                self._sock.sendall(req)
+            except socket.error as e:
+                raise IOError(f"TCP send failed: {e}") from e
+        else:
+            raise RuntimeError("Neither serial nor socket settings are configured.")
+
+    def _socket_recvall(self, size: int, flags: int = 0) -> bytes:
+        """Receive exactly bufsize bytes from the socket.
+
+        The return value is a bytes object representing the data received.
+        See the Unix manual page recv(2) for the meaning of the optional
+        argument *flags*; it defaults to zero.
+
+        TODO param, returns, rtype
+        """
+        assert self._sock is not None, "connection not established"
+        buffer = bytearray(size)
+        view = memoryview(buffer)
+        pos = 0
+        while pos < size:
+            read = self._sock.recv_into(view[pos:], size - pos, flags)
+            if not read:
+                return bytes(buffer[:pos])
+            pos += read
+        return bytes(buffer)
 
     def read_response(self) -> str:
         """Read the response message from the heat pump.
@@ -360,7 +491,7 @@ class HtHeatpump:
         :returns: The returned response message of the heat pump as :obj:`str`.
         :rtype: ``str``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the serial or TCP connection is not open or received an incomplete/invalid
             (or unknown) response (e.g. broken data stream, unknown header, invalid checksum, ...).
 
         .. note::
@@ -388,19 +519,41 @@ class HtHeatpump:
             must be corrected (for the checksum computation) so that the received checksum fits with the computed
             one (e.g. for ``b"\\x02\\xfd\\xe0\\xd0\\x01\\x00"`` and ``b"\\x02\\xfd\\xe0\\xd0\\x02\\x00"``).
         """
-        if not self._ser:
-            raise IOError("serial connection not open")
-        # read the header of the response message
-        header = self._ser.read(RESPONSE_HEADER_LEN)
-        if not header:
+        # Read header
+        try:
+            if self._ser_settings is not None:  # Use serial
+                if not self._ser:
+                    raise IOError("serial connection not open")
+                # read the header of the response message
+                header = self._ser.read(RESPONSE_HEADER_LEN)
+            elif self._sock_settings is not None:  # Use socket
+                if not self._sock:
+                    raise IOError("connection not established")
+                # read the header of the response message
+                header = self._socket_recvall(RESPONSE_HEADER_LEN)
+            else:
+                raise RuntimeError("Neither serial nor socket settings are configured.")
+        except (IOError, socket.error, serial.SerialException) as e:
+            raise IOError(f"Failed reading response header: {e}") from e
+
+        if not header or len(header) < RESPONSE_HEADER_LEN:
             raise IOError("data stream broken during reading response header")
         elif header not in RESPONSE_HEADER:
             raise IOError("invalid or unknown response header [{}]".format(header))
+
         # read the length of the following payload
-        payload_len_r = self._ser.read(1)
+        try:
+            if self._ser is not None:
+                payload_len_r = self._ser.read(1)
+            else:  # Socket
+                payload_len_r = self._socket_recvall(1)
+        except (IOError, socket.error, serial.SerialException) as e:
+            raise IOError(f"Failed reading payload length: {e}") from e
+
         if not payload_len_r:
             raise IOError("data stream broken during reading payload length")
         payload_len = payload_len_r = payload_len_r[0]
+
         # We don't know why, but for some messages (e.g. for the error message "ERR,INVALID IDX") the
         # heat pump answers with a payload length of zero bytes. In order to also accept such responses
         # we read until we will found the trailing "\r\n" at the end of the payload. The payload length
@@ -413,7 +566,15 @@ class HtHeatpump:
             )
             payload = b""
             while payload[-2:] != b"\r\n":
-                tmp = self._ser.read(1)
+                try:
+                    # --- Start of Correction 1 ---
+                    if self._ser is not None:  # Check self._ser
+                        tmp = self._ser.read(1)
+                    else:  # Socket (self._sock_settings must be not None)
+                        tmp = self._socket_recvall(1)
+                except (IOError, socket.error, serial.SerialException) as e:
+                    raise IOError(f"Failed reading payload chunk (len=0): {e}") from e
+
                 if not tmp:
                     raise IOError(
                         "data stream broken during reading payload ending with '\\r\\n'"
@@ -423,17 +584,32 @@ class HtHeatpump:
             payload_len = len(payload)
         else:
             # read the payload itself
-            payload = self._ser.read(payload_len)
+            try:
+                if self._ser is not None:  # Check self._ser
+                    payload = self._ser.read(payload_len_r)  # Read using the original reported length
+                else:  # Socket (self._sock_settings must be not None)
+                    payload = self._socket_recvall(payload_len_r)  # Read using the original reported length
+            except (IOError, socket.error, serial.SerialException) as e:
+                raise IOError(f"Failed reading payload (len={payload_len_r}): {e}") from e
+
             if not payload or len(payload) < payload_len:
                 raise IOError("data stream broken during reading payload")
         # depending on the received header correct the payload length for the checksum computation,
         #   so that the received checksum fits with the computed one
         payload_len = RESPONSE_HEADER[header]["payload_len"](payload_len)
         # read the checksum and verify the validity of the response
-        checksum = self._ser.read(1)
+        try:
+            if self._ser is not None:
+                checksum = self._ser.read(1)
+            else:  # Socket
+                checksum = self._socket_recvall(1)
+        except (IOError, socket.error, serial.SerialException) as e:
+            raise IOError(f"Failed reading checksum: {e}") from e
+
         if not checksum:
             raise IOError("data stream broken during reading checksum")
         checksum = checksum[0]
+
         # compute the checksum over header, payload length and the payload itself (depending on the header)
         comp_checksum = RESPONSE_HEADER[header]["checksum"](
             header, payload_len, payload
@@ -441,7 +617,7 @@ class HtHeatpump:
         if checksum != comp_checksum:
             raise IOError(
                 "invalid checksum [{}] of response "
-                "[header={}, payload_len={:d}({:d}), payload={}, checksum={}]".format(
+                "[header={!r}, payload_len={:d}({:d}), payload={!r}, checksum={}]".format(
                     hex(checksum),
                     header,
                     payload_len,
@@ -459,11 +635,12 @@ class HtHeatpump:
         _LOGGER.debug("  payload length = %d(%d)", payload_len, payload_len_r)
         _LOGGER.debug("  payload = %s", payload)
         _LOGGER.debug("  checksum = %s", hex(checksum))
+
         # extract the relevant data from the payload (without header '~' and trailer ';\r\n')
         m = re.match(r"^~([^;]*);\r\n$", payload.decode("ascii"))
         if not m:
             raise IOError(
-                "failed to extract response data from payload [{}]".format(payload)
+                "failed to extract response data from payload [{!r}]".format(payload)
             )
         return m.group(1)
 
@@ -485,7 +662,7 @@ class HtHeatpump:
             Default is :attr:`DEFAULT_LOGIN_RETRIES`.
         :type max_retries: int
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         # we try to login the heat pump for several times
@@ -539,7 +716,7 @@ class HtHeatpump:
         :returns: The manufacturer's serial number of the heat pump as :obj:`int` (e.g. :data:`123456`).
         :rtype: ``int``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         # send RID request to the heat pump
@@ -572,7 +749,7 @@ class HtHeatpump:
 
         :rtype: ``tuple`` ( str, int )
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         # send request command to the heat pump
@@ -611,7 +788,7 @@ class HtHeatpump:
 
         :rtype: ``tuple`` ( datetime.datetime, int )
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         # send CLK request to the heat pump
@@ -652,7 +829,7 @@ class HtHeatpump:
             Raised for an invalid type of argument :attr:`dt`. Must be :const:`None` or
             of type :class:`datetime.datetime`.
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         if dt is None:
@@ -707,7 +884,7 @@ class HtHeatpump:
 
         :rtype: ``tuple`` ( int, int, datetime.datetime, str )
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         # send ALC request to the heat pump
@@ -740,7 +917,7 @@ class HtHeatpump:
         :returns: The size of the fault list as :obj:`int`.
         :rtype: ``int``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         # send ALS request to the heat pump
@@ -777,7 +954,7 @@ class HtHeatpump:
 
         :rtype: ``list``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         if not args:
@@ -1071,7 +1248,7 @@ class HtHeatpump:
         :raises KeyError:
             Will be raised when the parameter definition for the passed parameter is not found.
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         :raises VerificationException:
             Will be raised if the parameter verification fails and the property :attr:`~HtHeatpump.verify_param_error`
@@ -1125,7 +1302,7 @@ class HtHeatpump:
             Will be raised if the passed value is beyond the parameter limits and argument :attr:`ignore_limits`
             is set to :const:`False`.
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         :raises VerificationException:
             Will be raised if the parameter verification fails and the property :attr:`~HtHeatpump.verify_param_error`
@@ -1211,7 +1388,7 @@ class HtHeatpump:
         :returns: :const:`True` if the heat pump is malfunctioning, :const:`False` otherwise.
         :rtype: ``bool``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         return cast(bool, self.get_param("Stoerung"))
@@ -1235,7 +1412,7 @@ class HtHeatpump:
         :raises KeyError:
             Will be raised when the parameter definition for a passed parameter is not found.
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         :raises VerificationException:
             Will be raised if the parameter verification fails and the property :attr:`~HtHeatpump.verify_param_error`
@@ -1281,7 +1458,7 @@ class HtHeatpump:
         :raises ValueError:
             Will be raised when a passed parameter doesn't represent a "MP" data point.
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         if not args:
@@ -1368,7 +1545,7 @@ class HtHeatpump:
         :returns: A list of :class:`~htheatpump.httimeprog.TimeProgram` instances.
         :rtype: ``list``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         time_progs = []
@@ -1420,7 +1597,7 @@ class HtHeatpump:
             their time program entries.
         :rtype: ``TimeProgram``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         assert isinstance(idx, int)
@@ -1463,7 +1640,7 @@ class HtHeatpump:
             with their time program entries.
         :rtype: ``TimeProgram``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         assert isinstance(idx, int)
@@ -1530,7 +1707,7 @@ class HtHeatpump:
         :returns: The requested time program as :class:`~htheatpump.httimeprog.TimeProgram`.
         :rtype: ``TimeProgram``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         assert isinstance(idx, int)
@@ -1555,7 +1732,7 @@ class HtHeatpump:
         :returns: The requested time program entry as :class:`~htheatpump.httimeprog.TimeProgEntry`.
         :rtype: ``TimeProgEntry``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         assert isinstance(idx, int)
@@ -1605,7 +1782,7 @@ class HtHeatpump:
         :returns: The changed time program entry :class:`~htheatpump.httimeprog.TimeProgEntry`.
         :rtype: ``TimeProgEntry``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         assert isinstance(idx, int)
@@ -1654,7 +1831,7 @@ class HtHeatpump:
         :returns: The time program as :class:`~htheatpump.httimeprog.TimeProgram` including all time program entries.
         :rtype: ``TimeProgram``
         :raises IOError:
-            Will be raised when the serial connection is not open or received an incomplete/invalid
+            Will be raised when the connection is not established or received an incomplete/invalid
             response (e.g. broken data stream, invalid checksum).
         """
         assert isinstance(time_prog, TimeProgram)

--- a/htheatpump/htheatpump.py
+++ b/htheatpump/htheatpump.py
@@ -34,7 +34,7 @@ import serial
 import socket
 from urllib.parse import urlparse
 
-from .htparams import HtParams, HtParamValueType
+from .htparams import HtParam, HtParams, HtParamValueType
 from .httimeprog import TimeProgEntry, TimeProgram
 from .protocol import (
     ALC_CMD,
@@ -1052,7 +1052,7 @@ class HtHeatpump:
         assert (
             name in HtParams
         ), "parameter definition for parameter {!r} not found".format(name)
-        param = HtParams[name]  # type:ignore
+        param: HtParam = HtParams[name]  # type: ignore
         # search for pattern "NAME=...", "VAL=...", "MAX=..." and "MIN=..." inside the response string
         m = re.match(
             r"^{},.*NAME=([^,]+).*VAL=([^,]+).*MAX=([^,]+).*MIN=([^,]+).*$".format(
@@ -1111,7 +1111,7 @@ class HtHeatpump:
         assert (
             name in HtParams
         ), "parameter definition for parameter {!r} not found".format(name)
-        param = HtParams[name]  # type: ignore
+        param: HtParam = HtParams[name]  # type: ignore
         # send command to the heat pump
         self.send_request(param.cmd())
         # ... and wait for the response
@@ -1158,7 +1158,7 @@ class HtHeatpump:
         assert (
             name in HtParams
         ), "parameter definition for parameter {!r} not found".format(name)
-        param = HtParams[name]  # type: ignore
+        param: HtParam = HtParams[name]  # type: ignore
         try:
             # verify 'NAME'
             if (VerifyAction.NAME in self._verify_param_action) and (resp_name != name):
@@ -1323,7 +1323,7 @@ class HtHeatpump:
             raise KeyError(
                 "parameter definition for parameter {!r} not found".format(name)
             )
-        param = HtParams[name]  # type: ignore
+        param: HtParam = HtParams[name]  # type: ignore
         # check the passed value against the defined limits (if desired)
         if not ignore_limits and not param.in_limits(val):
             raise ValueError(
@@ -1332,8 +1332,8 @@ class HtHeatpump:
                 )
             )
         # send command to the heat pump
-        val = param.to_str(val)
-        self.send_request("{},VAL={}".format(param.cmd(), val))
+        val_str = param.to_str(val)
+        self.send_request("{},VAL={}".format(param.cmd(), val_str))
         # ... and wait for the response
         try:
             resp = self.read_response()
@@ -1356,7 +1356,7 @@ class HtHeatpump:
             raise KeyError(
                 "parameter definition for parameter {!r} not found".format(name)
             )
-        param = HtParams[name]  # type: ignore
+        param: HtParam = HtParams[name]  # type: ignore
         # check the passed value against the defined limits (if desired)
         if not ignore_limits and not param.in_limits(val):
             raise ValueError(
@@ -1368,8 +1368,8 @@ class HtHeatpump:
         if val is None:
             self.send_request("{},ORF=0".format(param.cmd()))
         else:
-            val = param.to_str(val)
-            self.send_request("{},ORV={},ORF=1".format(param.cmd(), val))
+            val_str = param.to_str(val)
+            self.send_request("{},ORV={},ORF=1".format(param.cmd(), val_str))
         # ... and wait for the response
         try:
             resp = self.read_response()
@@ -1473,7 +1473,7 @@ class HtHeatpump:
                 raise KeyError(
                     "parameter definition for parameter {!r} not found".format(name)
                 )
-            param = HtParams[name]  # type: ignore
+            param: HtParam = HtParams[name]  # type: ignore
             if param.dp_type != "MP":
                 raise ValueError(
                     "invalid parameter {!r}; only parameters representing a 'MP' data point are allowed".format(

--- a/htheatpump/protocol.py
+++ b/htheatpump/protocol.py
@@ -20,7 +20,7 @@
 """ Protocol constants and functions for the Heliotherm heat pump communication. """
 
 
-from typing import Final
+from typing import Any, Dict, Final
 
 # ------------------------------------------------------------------------------------------------------------------- #
 # Protocol constants
@@ -31,7 +31,7 @@ MAX_CMD_LENGTH: Final = 253  # 253 = 255 - 1 byte for header - 1 byte for traile
 
 REQUEST_HEADER: Final = b"\x02\xfd\xd0\xe0\x00\x00"
 RESPONSE_HEADER_LEN: Final = 6  # response header length
-RESPONSE_HEADER: Final = {
+RESPONSE_HEADER: Final[Dict[bytes, Dict[str, Any]]] = {
     #
     # NOTE:
     # =====

--- a/htheatpump/scripts/htbackup.py
+++ b/htheatpump/scripts/htbackup.py
@@ -24,13 +24,15 @@
     .. code-block:: shell
 
        $ python3 htbackup.py --baudrate 9600 --csv backup.csv
-       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4', ORV='', ORF=''
-       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1', ORV='', ORF=''
-       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1', ORV='', ORF=''
+       or
+       $ python3 htbackup.py --url "tcp://localhost:9999" --csv backup.csv
+       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
+       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
+       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
        ...
-       'MP,NR=0' [Temp. Aussen]: VAL='3.5', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='3.8', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=2' [Temp. Brauchwasser]: VAL='46.1', MIN='0.0', MAX='70.0', ORV='0.0', ORF='0'
+       'MP,NR=0' [Temp. Aussen]: VAL='-7.0', MIN='-20.0', MAX='40.0'
+       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='-6.9', MIN='-20.0', MAX='40.0'
+       'MP,NR=2' [Temp. Brauchwasser]: VAL='45.7', MIN='0.0', MAX='70.0'
        ...
 """
 
@@ -59,6 +61,8 @@ def main() -> None:
             Example:
 
               $ python3 htbackup.py --baudrate 9600 --csv backup.csv
+              or
+              $ python3 htbackup.py --url "tcp://localhost:9999" --csv backup.csv
               'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
               'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
               'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
@@ -82,6 +86,11 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u", "--url", type=str,
+        help="the TCP URL (e.g., tcp://192.168.1.100:9999). Provide either --device or --url.",
     )
 
     parser.add_argument(
@@ -135,7 +144,15 @@ def main() -> None:
         help="maximum number of retries for a data point request (0..10), default: %(default)s",
     )
 
+    parser.add_argument(
+        "--timeout", type=float, default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
+
+    if not args.device and not args.url:
+        parser.error("Either --device or --url must be specified.")
 
     # activate logging with level DEBUG in verbose mode
     log_format = "%(asctime)s %(levelname)s [%(name)s|%(funcName)s]: %(message)s"
@@ -144,8 +161,16 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if args.url:
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("Using TCP connection: %s", args.url)
+        else:  # args.device must be set
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("Using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 
@@ -245,7 +270,7 @@ def main() -> None:
                 json.dump(result, jsonfile, indent=4, sort_keys=True)
 
         if args.csv:  # write result to CSV file
-            with open(args.csv, "w") as csvfile:
+            with open(args.csv, "w", encoding="utf-8") as csvfile:
                 fieldnames = ["type", "number", "name", "value", "min", "max", "orv", "orf"]
                 writer = csv.DictWriter(csvfile, delimiter=",", fieldnames=fieldnames)
                 writer.writeheader()

--- a/htheatpump/scripts/htbackup_async.py
+++ b/htheatpump/scripts/htbackup_async.py
@@ -24,13 +24,15 @@
     .. code-block:: shell
 
        $ python3 htbackup_async.py --baudrate 9600 --csv backup.csv
-       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4', ORV='', ORF=''
-       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1', ORV='', ORF=''
-       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1', ORV='', ORF=''
+       or
+       $ python3 htbackup_async.py --url "tcp://localhost:9999" --csv backup.csv
+       'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
+       'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
+       'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
        ...
-       'MP,NR=0' [Temp. Aussen]: VAL='3.5', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='3.8', MIN='-20.0', MAX='40.0', ORV='0.0', ORF='0'
-       'MP,NR=2' [Temp. Brauchwasser]: VAL='46.1', MIN='0.0', MAX='70.0', ORV='0.0', ORF='0'
+       'MP,NR=0' [Temp. Aussen]: VAL='-7.0', MIN='-20.0', MAX='40.0'
+       'MP,NR=1' [Temp. Aussen verzoegert]: VAL='-6.9', MIN='-20.0', MAX='40.0'
+       'MP,NR=2' [Temp. Brauchwasser]: VAL='45.7', MIN='0.0', MAX='70.0'
        ...
 """
 
@@ -60,6 +62,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htbackup_async.py --baudrate 9600 --csv backup.csv
+              or
+              $ python3 htbackup_async.py --url "tcp://localhost:9999" --csv backup.csv
               'SP,NR=0' [Language]: VAL='0', MIN='0', MAX='4'
               'SP,NR=1' [TBF_BIT]: VAL='0', MIN='0', MAX='1'
               'SP,NR=2' [Rueckruferlaubnis]: VAL='1', MIN='0', MAX='1'
@@ -83,6 +87,11 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u", "--url", type=str,
+        help="the TCP URL (e.g., tcp://192.168.1.100:9999). Provide either --device or --url.",
     )
 
     parser.add_argument(
@@ -136,7 +145,15 @@ async def main_async() -> None:
         help="maximum number of retries for a data point request (0..10), default: %(default)s",
     )
 
+    parser.add_argument(
+        "--timeout", type=float, default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
+
+    if not args.device and not args.url:
+        parser.error("Either --device or --url must be specified.")
 
     # activate logging with level DEBUG in verbose mode
     log_format = "%(asctime)s %(levelname)s [%(name)s|%(funcName)s]: %(message)s"
@@ -145,8 +162,16 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if args.url:
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("Using TCP connection: %s", args.url)
+        else:  # args.device must be set
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("Using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -225,7 +250,7 @@ async def main_async() -> None:
                                 ex,
                             )
                             # try a reconnect, maybe this will help
-                            hp.reconnect()  # perform a reconnect
+                            await hp.reconnect_async()  # perform a reconnect
                             try:
                                 await hp.login_async(
                                     max_retries=0
@@ -248,7 +273,7 @@ async def main_async() -> None:
                 json.dump(result, jsonfile, indent=4, sort_keys=True)
 
         if args.csv:  # write result to CSV file
-            with open(args.csv, "w") as csvfile:
+            with open(args.csv, "w", encoding="utf-8") as csvfile:
                 fieldnames = ["type", "number", "name", "value", "min", "max", "orv", "orf"]
                 writer = csv.DictWriter(csvfile, delimiter=",", fieldnames=fieldnames)
                 writer.writeheader()
@@ -267,7 +292,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htcomplparams.py
+++ b/htheatpump/scripts/htcomplparams.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htcomplparams.py --device /dev/ttyUSB1 --baudrate 9600 --csv
+       or
+       $ python3 htcomplparams.py --url "tcp://localhost:9999" --csv
        connected successfully to heat pump with serial number 123456
        software version = 3.0.20 (273)
        'SP,NR=0' [Language]: VAL=0, MIN=0, MAX=4 (dtype=INT)
@@ -59,6 +61,8 @@ def main() -> None:
             Example:
 
               $ python3 htcomplparams.py --device /dev/ttyUSB1 --baudrate 9600 --csv
+              or
+              $ python3 htcomplparams.py --url "tcp://localhost:9999" --csv
               connected successfully to heat pump with serial number 123456
               software version = 3.0.20 (273)
               'SP,NR=0' [Language]: VAL=0, MIN=0, MAX=4 (dtype=INT)
@@ -85,6 +89,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -133,6 +144,14 @@ def main() -> None:
         help="maximum number of retries for a data point request (0..10), default: %(default)s",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -142,8 +161,18 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htcomplparams_async.py
+++ b/htheatpump/scripts/htcomplparams_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htcomplparams_async.py --device /dev/ttyUSB1 --baudrate 9600 --csv
+       or
+       $ python3 htcomplparams_async.py --url "tcp://localhost:9999" --csv
        connected successfully to heat pump with serial number 123456
        software version = 3.0.20 (273)
        'SP,NR=0' [Language]: VAL=0, MIN=0, MAX=4 (dtype=INT)
@@ -60,6 +62,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htcomplparams_async.py --device /dev/ttyUSB1 --baudrate 9600 --csv
+              or
+              $ python3 htcomplparams_async.py --url "tcp://localhost:9999" --csv
               connected successfully to heat pump with serial number 123456
               software version = 3.0.20 (273)
               'SP,NR=0' [Language]: VAL=0, MIN=0, MAX=4 (dtype=INT)
@@ -86,6 +90,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -134,6 +145,14 @@ async def main_async() -> None:
         help="maximum number of retries for a data point request (0..10), default: %(default)s",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -143,8 +162,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -235,7 +264,7 @@ async def main_async() -> None:
                                 ex,
                             )
                             # try a reconnect, maybe this will help
-                            hp.reconnect()  # perform a reconnect
+                            await hp.reconnect_async()  # perform a reconnect
                             try:
                                 await hp.login_async(
                                     max_retries=0
@@ -297,7 +326,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htdatetime.py
+++ b/htheatpump/scripts/htdatetime.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htdatetime.py --device /dev/ttyUSB1 --baudrate 9600
+       or
+       $ python3 htdatetime.py --url "tcp://localhost:9999"
        Tuesday, 2017-11-21T21:48:04
        $ python3 htdatetime.py -d /dev/ttyUSB1 -b 9600 "2008-09-03T20:56:35"
        Wednesday, 2008-09-03T20:56:35
@@ -69,6 +71,8 @@ def main() -> None:
             Example:
 
               $ python3 htdatetime.py --device /dev/ttyUSB1 --baudrate 9600
+              or
+              $ python3 htdatetime.py --url "tcp://localhost:9999"
               Tuesday, 2017-11-21T21:48:04
               $ python3 htdatetime.py -d /dev/ttyUSB1 -b 9600 "2008-09-03T20:56:35"
               Wednesday, 2008-09-03T20:56:35
@@ -91,6 +95,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -130,6 +141,14 @@ def main() -> None:
         "if not specified current date and time on the heat pump will be returned",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -139,8 +158,18 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htdatetime_async.py
+++ b/htheatpump/scripts/htdatetime_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htdatetime_async.py --device /dev/ttyUSB1 --baudrate 9600
+       or
+       $ python3 htdatetime_async.py --url "tcp://localhost:9999"
        Tuesday, 2017-11-21T21:48:04
        $ python3 htdatetime_async.py -d /dev/ttyUSB1 -b 9600 "2008-09-03T20:56:35"
        Wednesday, 2008-09-03T20:56:35
@@ -70,6 +72,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htdatetime_async.py --device /dev/ttyUSB1 --baudrate 9600
+              or
+              $ python3 htdatetime_async.py --url "tcp://localhost:9999"
               Tuesday, 2017-11-21T21:48:04
               $ python3 htdatetime_async.py -d /dev/ttyUSB1 -b 9600 "2008-09-03T20:56:35"
               Wednesday, 2008-09-03T20:56:35
@@ -92,6 +96,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -131,6 +142,14 @@ async def main_async() -> None:
         "if not specified current date and time on the heat pump will be returned",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -140,8 +159,17 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
         hp.open_connection()
         await hp.login_async()
 
@@ -182,7 +210,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htfastquery.py
+++ b/htheatpump/scripts/htfastquery.py
@@ -25,6 +25,8 @@
     .. code-block:: shell
 
        $ python3 htfastquery.py --device /dev/ttyUSB1 "Temp. Vorlauf" "Temp. Ruecklauf"
+       or
+       $ python3 htfastquery.py --url "tcp://localhost:9999" "Temp. Vorlauf" "Temp. Ruecklauf"
        Temp. Ruecklauf [MP,04]: 25.2
        Temp. Vorlauf   [MP,03]: 25.3
 
@@ -60,6 +62,8 @@ def main() -> None:
             Example:
 
               $ python3 htfastquery.py --device /dev/ttyUSB1 "Temp. Vorlauf" "Temp. Ruecklauf"
+              or
+              $ python3 htfastquery.py --url "tcp://localhost:9999" "Temp. Vorlauf" "Temp. Ruecklauf"
               Temp. Ruecklauf [MP,04]: 25.2
               Temp. Vorlauf   [MP,03]: 25.3
             """
@@ -81,6 +85,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -130,6 +141,14 @@ def main() -> None:
         "all known parameters representing a MP data point",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -139,8 +158,18 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htfaultlist.py
+++ b/htheatpump/scripts/htfaultlist.py
@@ -63,6 +63,8 @@ def main() -> None:
             Example:
 
               $ python3 htfaultlist.py --device /dev/ttyUSB1
+              or
+              $ python3 htfaultlist.py --url "tcp://localhost:9999"
               #000 [2000-01-01T00:00:00]: 65534, Keine Stoerung
               #001 [2000-01-01T00:00:00]: 65286, Info: Programmupdate 1
               #002 [2000-01-01T00:00:00]: 65285, Info: Initialisiert
@@ -87,6 +89,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -137,6 +146,14 @@ def main() -> None:
         "index", type=int, nargs="*", help="fault list index/indices to query for"
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -146,8 +163,17 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htfaultlist_async.py
+++ b/htheatpump/scripts/htfaultlist_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htfaultlist_async.py --device /dev/ttyUSB1 --baudrate 9600
+       or
+       $ python3 htfaultlist_async.py --url "tcp://localhost:9999"
        #000 [2000-01-01T00:00:00]: 65534, Keine Stoerung
        #001 [2000-01-01T00:00:00]: 65286, Info: Programmupdate 1
        #002 [2000-01-01T00:00:00]: 65285, Info: Initialisiert
@@ -64,6 +66,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htfaultlist_async.py --device /dev/ttyUSB1
+              or
+              $ python3 htfaultlist_async.py --url "tcp://localhost:9999"
               #000 [2000-01-01T00:00:00]: 65534, Keine Stoerung
               #001 [2000-01-01T00:00:00]: 65286, Info: Programmupdate 1
               #002 [2000-01-01T00:00:00]: 65285, Info: Initialisiert
@@ -88,6 +92,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -138,6 +149,14 @@ async def main_async() -> None:
         "index", type=int, nargs="*", help="fault list index/indices to query for"
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -147,8 +166,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -214,7 +243,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/scripts/htquery.py
+++ b/htheatpump/scripts/htquery.py
@@ -32,6 +32,12 @@
            "Stoerung": false,
            "Temp. Aussen": 3.2
        }
+
+       $ python3 htquery.py --url "tcp://hostname:port" "Temp. Aussen" "Stoerung"
+       {
+           "Stoerung": false,
+           "Temp. Aussen": 3.2
+       }
 """
 
 import argparse
@@ -58,6 +64,8 @@ def main() -> None:
             Example:
 
               $ python3 htquery.py --device /dev/ttyUSB1 "Temp. Aussen" "Stoerung"
+              or
+              $ python3 htquery.py --url "tcp://192.168.1.2:9999" "Temp. Aussen" "Stoerung"
               Stoerung    : False
               Temp. Aussen: 5.0
             """
@@ -79,6 +87,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -127,6 +142,14 @@ def main() -> None:
         help="parameter name(s) to query for (as defined in htparams.csv) or omit to query for all known parameters",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -136,8 +159,18 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htset.py
+++ b/htheatpump/scripts/htset.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htset.py --device /dev/ttyUSB1 "HKR Soll_Raum" "21.5"
+       or
+       $ python3 htset.py --url "tcp://localhost:9999" "HKR Soll_Raum" "21.5"
        21.5
 """
 
@@ -58,6 +60,8 @@ def main() -> None:
             Example:
 
               $ python3 htset.py --device /dev/ttyUSB1 "HKR Soll_Raum" "21.5"
+              or
+              $ python3 htset.py --url "tcp://localhost:9999" "HKR Soll_Raum" "21.5"
               21.5
             """
         ),
@@ -78,6 +82,13 @@ def main() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -117,6 +128,14 @@ def main() -> None:
         help="parameter name (as defined in htparams.csv)",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=HtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     parser.add_argument("value", type=str, nargs=1, help="parameter value (as string)")
 
     args = parser.parse_args()
@@ -128,8 +147,17 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = HtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = HtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = HtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
         hp.open_connection()
         hp.login()
 

--- a/htheatpump/scripts/htshell_async.py
+++ b/htheatpump/scripts/htshell_async.py
@@ -24,6 +24,8 @@
     .. code-block:: shell
 
        $ python3 htshell_async.py --device /dev/ttyUSB1 --baudrate 9600 "AR,28,29,30" -r 3
+       or
+       $ python3 htshell_async.py --url "tcp://localhost:9999" "AR,28,29,30" -r 3
        > 'AR,28,29,30'
        < 'AA,28,19,14.09.14-02:08:56,EQ_Spreizung'
        < 'AA,29,20,14.09.14-11:52:08,EQ_Spreizung'
@@ -57,6 +59,8 @@ async def main_async() -> None:
             Example:
 
               $ python3 htshell_async.py --device /dev/ttyUSB1 "AR,28,29,30" -r 3
+              or
+              $ python3 htshell_async.py --url "tcp://localhost:9999" "AR,28,29,30" -r 3
               > 'AR,28,29,30'
               < 'AA,28,19,14.09.14-02:08:56,EQ_Spreizung'
               < 'AA,29,20,14.09.14-11:52:08,EQ_Spreizung'
@@ -80,6 +84,13 @@ async def main_async() -> None:
             """
         )
         + "\r\n",
+    )
+
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="the (TCP socket) url on which the heat pump is connected",
     )
 
     parser.add_argument(
@@ -126,6 +137,14 @@ async def main_async() -> None:
         help="command(s) to send to the heat pump (without the preceding '~' and the trailing ';')",
     )
 
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        # Use the default timeout defined in the HtHeatpump class
+        default=AioHtHeatpump.DEFAULT_TIMEOUT,
+        help="connection timeout in seconds, default: %(default)s",
+    )
+
     args = parser.parse_args()
 
     # activate logging with level DEBUG in verbose mode
@@ -135,8 +154,18 @@ async def main_async() -> None:
     else:
         logging.basicConfig(level=logging.WARNING, format=log_format)
 
-    hp = AioHtHeatpump(args.device, baudrate=args.baudrate)
     try:
+        if (args.url):
+            # Use keyword argument 'url'
+            hp = AioHtHeatpump(url=args.url, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--url specified, using url-based connection: %s", args.url)
+        else:
+            # Use keyword argument 'device' and pass serial-specific options
+            hp = AioHtHeatpump(device=args.device, baudrate=args.baudrate, timeout=args.timeout)
+            if args.verbose:
+                _LOGGER.info("--device specified, using serial connection: %s", args.device)
+
         hp.open_connection()
         await hp.login_async()
 
@@ -169,7 +198,7 @@ async def main_async() -> None:
         sys.exit(1)
     finally:
         await hp.logout_async()  # try to logout for an ordinary cancellation (if possible)
-        hp.close_connection()
+        await hp.close_connection_async()
 
     sys.exit(0)
 

--- a/htheatpump/utils.py
+++ b/htheatpump/utils.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 
 import timeit
-from typing import Any
+from typing import Any, ClassVar
 
 
 class Singleton:
@@ -48,6 +48,8 @@ class Singleton:
     .. seealso::
         https://mail.python.org/pipermail/python-list/2007-July/431423.html
     """
+
+    _inst: ClassVar[Any]
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Singleton:
         """Create a new instance."""

--- a/requirements/doc.pip
+++ b/requirements/doc.pip
@@ -1,2 +1,2 @@
-Sphinx==5.3.0
+Sphinx==7.3.7
 sphinx_rtd_theme==2.0.0

--- a/requirements/doc.pip
+++ b/requirements/doc.pip
@@ -1,2 +1,2 @@
-Sphinx==7.3.7
+Sphinx==5.3.0
 sphinx_rtd_theme==2.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def pytest_addoption(parser: Any) -> None:
     parser.addoption("--connected", action="store_true", dest="run_if_connected", default=False)
     parser.addoption("--device", action="store", default="/dev/ttyUSB0")
     parser.addoption("--baudrate", action="store", default=115200)
+    parser.addoption("--url", action="store", default=None, help="TCP URL for testing (e.g., tcp://192.168.1.100:9999)")
     parser.addoption("--loglevel", action="store", default=logging.WARNING)
 
 
@@ -40,6 +41,9 @@ def pytest_configure(config: Any) -> None:
     print("connected: {}".format("NO" if not config.option.run_if_connected else "YES"))
     print("device: {}".format(config.getoption("--device")))
     print("baudrate: {:d}".format(int(config.getoption("--baudrate"))))
+    url = config.getoption("--url")
+    if url:
+        print("url: {}".format(url))
     print("loglevel: {:d}".format(loglevel))
 
 
@@ -51,3 +55,8 @@ def cmdopt_device(request: Any) -> Any:
 @pytest.fixture(scope="session")
 def cmdopt_baudrate(request: Any) -> Any:
     return request.config.getoption("--baudrate")
+
+
+@pytest.fixture(scope="session")
+def cmdopt_url(request: Any) -> Any:
+    return request.config.getoption("--url")

--- a/tests/test_htheatpump.py
+++ b/tests/test_htheatpump.py
@@ -137,6 +137,53 @@ def test_create_request(cmd: str, result: bytes) -> None:
     # assert 0
 
 
+# TCP Socket Tests
+def test_HtHeatpump_tcp_init_valid_url() -> None:
+    """Test TCP initialization with valid URL."""
+    hp = HtHeatpump(url="tcp://192.168.1.100:9999")
+    assert hp._sock_settings is not None
+    assert hp._sock_settings["address"] == ("192.168.1.100", 9999)
+    assert hp._sock_settings["timeout"] == HtHeatpump.DEFAULT_TIMEOUT
+    assert hp._ser_settings is None
+
+
+def test_HtHeatpump_tcp_init_custom_timeout() -> None:
+    """Test TCP initialization with custom timeout."""
+    hp = HtHeatpump(url="tcp://localhost:8080", timeout=10)
+    assert hp._sock_settings is not None
+    assert hp._sock_settings["timeout"] == 10
+
+
+def test_HtHeatpump_tcp_init_invalid_scheme() -> None:
+    """Test that invalid URL scheme raises ValueError."""
+    with pytest.raises(ValueError, match="invalid scheme for url, must be 'tcp'"):
+        HtHeatpump(url="http://localhost:9999")
+
+
+def test_HtHeatpump_tcp_init_both_device_and_url() -> None:
+    """Test that providing both device and url raises ValueError."""
+    with pytest.raises(ValueError, match="Exactly one of 'device' or 'url' must be provided"):
+        HtHeatpump(device="/dev/ttyUSB0", url="tcp://localhost:9999")
+
+
+def test_HtHeatpump_tcp_init_neither_device_nor_url() -> None:
+    """Test that providing neither device nor url raises ValueError."""
+    with pytest.raises(ValueError, match="Exactly one of 'device' or 'url' must be provided"):
+        HtHeatpump()
+
+
+@pytest.mark.parametrize("url,expected_host,expected_port", [
+    ("tcp://localhost:9999", "localhost", 9999),
+    ("tcp://192.168.1.100:8080", "192.168.1.100", 8080),
+    ("tcp://example.com:1234", "example.com", 1234),
+])
+def test_HtHeatpump_tcp_url_parsing(url: str, expected_host: str, expected_port: int) -> None:
+    """Test parsing of valid TCP URLs."""
+    hp = HtHeatpump(url=url)
+    assert hp._sock_settings is not None
+    assert hp._sock_settings["address"] == (expected_host, expected_port)
+
+
 @pytest.mark.run_if_connected
 def test_HtHeatpump_init_del(cmdopt_device: str, cmdopt_baudrate: int) -> None:
     hp = HtHeatpump(device=cmdopt_device, baudrate=cmdopt_baudrate)
@@ -148,8 +195,34 @@ def test_HtHeatpump_init_del(cmdopt_device: str, cmdopt_baudrate: int) -> None:
 
 
 @pytest.mark.run_if_connected
+def test_HtHeatpump_tcp_init_del(cmdopt_url: str) -> None:
+    """Test TCP connection initialization and cleanup."""
+    if not cmdopt_url:
+        pytest.skip("No TCP URL provided")
+    hp = HtHeatpump(url=cmdopt_url)
+    assert not hp.is_open
+    hp.open_connection()
+    assert hp.is_open
+    del hp  # HtHeatpump.__del__ should be executed here!
+    # assert 0
+
+
+@pytest.mark.run_if_connected
 def test_HtHeatpump_enter_exit(cmdopt_device: str, cmdopt_baudrate: int) -> None:
     with HtHeatpump(device=cmdopt_device, baudrate=cmdopt_baudrate) as hp:
+        assert hp is not None
+        assert hp.is_open
+    assert hp is not None
+    assert not hp.is_open
+    # assert 0
+
+
+@pytest.mark.run_if_connected
+def test_HtHeatpump_tcp_enter_exit(cmdopt_url: str) -> None:
+    """Test TCP connection with context manager."""
+    if not cmdopt_url:
+        pytest.skip("No TCP URL provided")
+    with HtHeatpump(url=cmdopt_url) as hp:
         assert hp is not None
         assert hp.is_open
     assert hp is not None

--- a/tests/test_htheatpump_tcp.py
+++ b/tests/test_htheatpump_tcp.py
@@ -1,0 +1,1188 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#  htheatpump - Serial communication module for Heliotherm heat pumps
+#  Copyright (C) 2023  Daniel Strigl
+
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" Tests for code in `htheatpump.htheatpump` using TCP socket connection. """
+
+import datetime
+import random
+import re
+from typing import AsyncGenerator, Generator, List, Set
+
+import pytest
+import pytest_asyncio
+
+from htheatpump.aiohtheatpump import AioHtHeatpump
+from htheatpump.htheatpump import HtHeatpump, VerifyAction
+from htheatpump.htparams import HtDataTypes, HtParam, HtParams
+from htheatpump.httimeprog import TimeProgEntry, TimeProgram
+
+
+@pytest.mark.run_if_connected
+def test_HtHeatpump_init_del(cmdopt_url: str) -> None:
+    hp = HtHeatpump(url=cmdopt_url)
+    assert not hp.is_open
+    hp.open_connection()
+    assert hp.is_open
+    del hp  # HtHeatpump.__del__ should be executed here!
+    # assert 0
+
+
+@pytest.mark.run_if_connected
+def test_HtHeatpump_enter_exit(cmdopt_url: str) -> None:
+    with HtHeatpump(url=cmdopt_url) as hp:
+        assert hp is not None
+        assert hp.is_open
+    assert hp is not None
+    assert not hp.is_open
+    # assert 0
+
+
+@pytest.fixture(scope="class")
+def hthp_tcp(cmdopt_url: str) -> Generator[HtHeatpump, None, None]:
+    ht_hp = HtHeatpump(url=cmdopt_url)
+    try:
+        ht_hp.open_connection()
+        yield ht_hp  # provide the heat pump instance
+    finally:
+        ht_hp.close_connection()
+
+
+@pytest_asyncio.fixture()
+async def reconnect_async(aiohthp_tcp: AioHtHeatpump) -> AsyncGenerator[None, None]:
+    await aiohthp_tcp.reconnect_async()
+    await aiohthp_tcp.login_async()
+    yield
+    await aiohthp_tcp.logout_async()
+
+
+class TestAioHtHeatpumpTCP:
+    @pytest.mark.run_if_connected
+    @pytest.mark.asyncio
+    async def test_open_connection(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        assert aiohthp_tcp.is_open
+        with pytest.raises(IOError):
+            aiohthp_tcp.open_connection()
+        # assert 0
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            VerifyAction.NONE(),
+            {VerifyAction.NAME},
+            {VerifyAction.NAME, VerifyAction.MIN},
+            {VerifyAction.NAME, VerifyAction.MIN, VerifyAction.MAX},
+            {VerifyAction.NAME, VerifyAction.MIN, VerifyAction.MAX, VerifyAction.VALUE},
+            {VerifyAction.MIN, VerifyAction.MAX, VerifyAction.VALUE},
+            {VerifyAction.MAX, VerifyAction.VALUE},
+            {VerifyAction.VALUE},
+            VerifyAction.ALL(),
+        ],
+    )
+    def test_verify_param_action(
+        self, cmdopt_url: str, action: Set[VerifyAction]
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        val = hp.verify_param_action
+        assert isinstance(val, set)
+        hp.verify_param_action = action
+        assert hp.verify_param_action == action
+        hp.verify_param_action = val
+        # assert 0
+
+    def test_verify_param_error(self, cmdopt_url: str) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        val = hp.verify_param_error
+        assert isinstance(val, bool)
+        hp.verify_param_error = True
+        assert hp.verify_param_error is True
+        hp.verify_param_error = False
+        assert hp.verify_param_error is False
+        hp.verify_param_error = val
+        # assert 0
+
+    @pytest.mark.asyncio
+    async def test_send_request(self, cmdopt_url: str) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(IOError):
+            await hp.send_request_async(r"LIN")
+        # assert 0
+
+    @pytest.mark.asyncio
+    async def test_read_response(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(IOError):
+            await hp.read_response_async()
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_serial_number(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        rid = await aiohthp_tcp.get_serial_number_async()
+        assert isinstance(rid, int), "'rid' must be of type int"
+        assert rid > 0
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_version(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        version = await aiohthp_tcp.get_version_async()
+        # ( "3.0.20", 2321 )
+        assert isinstance(version, tuple), "'version' must be of type tuple"
+        assert len(version) == 2
+        ver_str, ver_num = version
+        assert isinstance(ver_str, str), "'ver_str' must be of type str"
+        m = re.match(r"^(\d+).(\d+).(\d+)$", ver_str)
+        assert m is not None, "invalid version string [{!r}]".format(ver_str)
+        assert isinstance(ver_num, int), "'ver_num' must be of type int"
+        assert ver_num > 0
+        await aiohthp_tcp.send_request_async(r"SP,NR=9")
+        resp = await aiohthp_tcp.read_response_async()
+        m = re.match(r"^SP,NR=9,.*NAME=([^,]+).*VAL=([^,]+).*$", resp)
+        assert (
+            m is not None
+        ), "invalid response for query of the software version [{!r}]".format(resp)
+        assert ver_str == m.group(1).strip()
+        assert ver_num == int(m.group(2))
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_date_time(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        date_time = await aiohthp_tcp.get_date_time_async()
+        # (datetime.datetime(...), 2)  # 2 = Tuesday
+        assert isinstance(date_time, tuple), "'date_time' must be of type tuple"
+        assert len(date_time) == 2
+        dt, weekday = date_time
+        assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+        assert isinstance(weekday, int), "'weekday' must be of type int"
+        assert weekday in range(1, 8)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_set_date_time(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        dt_before, _ = await aiohthp_tcp.get_date_time_async()
+        dt_set, _ = await aiohthp_tcp.set_date_time_async()
+        dt_after, _ = await aiohthp_tcp.get_date_time_async()
+        assert (dt_after - dt_before).total_seconds() > 0
+        assert (dt_after - dt_set).total_seconds() < 2
+        # assert 0
+
+    @pytest.mark.asyncio
+    async def test_set_date_time_raises_TypeError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(TypeError):
+            await hp.set_date_time_async(123)  # type: ignore
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_last_fault(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        fault = await aiohthp_tcp.get_last_fault_async()
+        # (29, 20, datetime.datetime(...), "EQ_Spreizung")
+        assert isinstance(fault, tuple), "'fault' must be of type tuple"
+        assert len(fault) == 4
+        index, error, dt, msg = fault
+        assert isinstance(index, int), "'index' must be of type int"
+        assert 0 <= index < await aiohthp_tcp.get_fault_list_size_async()
+        assert isinstance(error, int), "'error' must be of type int"
+        assert error >= 0
+        assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+        assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_fault_list_size(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        size = await aiohthp_tcp.get_fault_list_size_async()
+        assert isinstance(size, int), "'size' must be of type int"
+        assert size >= 0
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_fault_list(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        fault_list = await aiohthp_tcp.get_fault_list_async()
+        assert isinstance(fault_list, list)
+        assert len(fault_list) == await aiohthp_tcp.get_fault_list_size_async()
+
+    # @pytest.mark.skip(reason="test needs a rework")
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_fault_list_in_several_pieces(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        args = []
+        cmd = ""
+        fault_list_size = await aiohthp_tcp.get_fault_list_size_async()
+        while len(cmd) < 255 * 2:  # request has do be done in 3 parts
+            item = random.randint(0, fault_list_size - 1)
+            cmd += ",{}".format(item)
+            args.append(item)
+        fault_list = await aiohthp_tcp.get_fault_list_async(*args)
+        # [ { "index": 29,  # fault list index
+        #     "error": 20,  # error code
+        #     "datetime": datetime.datetime(...),  # date and time of the entry
+        #     "message": "EQ_Spreizung",  # error message
+        #     },
+        #   # ...
+        #   ]
+        assert isinstance(fault_list, list), "'fault_list' must be of type list"
+        assert len(fault_list) == len(args)
+        for entry in fault_list:
+            assert isinstance(entry, dict), "'entry' must be of type dict"
+            index = entry["index"]
+            assert isinstance(index, int), "'index' must be of type int"
+            assert 0 <= index < fault_list_size
+            error = entry["error"]
+            assert isinstance(error, int), "'error' must be of type int"
+            assert error >= 0
+            dt = entry["datetime"]
+            assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+            msg = entry["message"]
+            assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_fault_list_with_index(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        size = await aiohthp_tcp.get_fault_list_size_async()
+        assert isinstance(size, int), "'size' must be of type int"
+        assert size >= 0
+        for i in range(size):
+            fault_list = await aiohthp_tcp.get_fault_list_async(i)
+            assert isinstance(fault_list, list), "'fault_list' must be of type list"
+            assert len(fault_list) == 1
+            entry = fault_list[0]
+            assert isinstance(entry, dict), "'entry' must be of type dict"
+            index = entry["index"]
+            assert isinstance(index, int), "'index' must be of type int"
+            assert 0 <= index < await aiohthp_tcp.get_fault_list_size_async()
+            error = entry["error"]
+            assert isinstance(error, int), "'error' must be of type int"
+            assert error >= 0
+            dt = entry["datetime"]
+            assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+            msg = entry["message"]
+            assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_fault_list_with_index_raises_IOError(
+        self, aiohthp_tcp: AioHtHeatpump
+    ) -> None:
+        with pytest.raises(IOError):
+            await aiohthp_tcp.get_fault_list_async(-1)
+        with pytest.raises(IOError):
+            await aiohthp_tcp.get_fault_list_async(await aiohthp_tcp.get_fault_list_size_async())
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_fault_list_with_indices(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        size = await aiohthp_tcp.get_fault_list_size_async()
+        for cnt in range(size + 1):
+            indices = random.sample(range(size), cnt)
+            fault_list = await aiohthp_tcp.get_fault_list_async(*indices)
+            assert isinstance(fault_list, list), "'fault_list' must be of type list"
+            assert len(fault_list) == (cnt if cnt > 0 else size)
+            for entry in fault_list:
+                assert isinstance(entry, dict), "'entry' must be of type dict"
+                index = entry["index"]
+                assert isinstance(index, int), "'index' must be of type int"
+                assert 0 <= index < await aiohthp_tcp.get_fault_list_size_async()
+                error = entry["error"]
+                assert isinstance(error, int), "'error' must be of type int"
+                assert error >= 0
+                dt = entry["datetime"]
+                assert isinstance(
+                    dt, datetime.datetime
+                ), "'dt' must be of type datetime"
+                msg = entry["message"]
+                assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize("name, param", HtParams.items())
+    @pytest.mark.asyncio
+    async def test_get_param(
+        self, aiohthp_tcp: AioHtHeatpump, name: str, param: HtParam
+    ) -> None:
+        value = await aiohthp_tcp.get_param_async(name)
+        assert value is not None, "'value' must not be None"
+        assert param.in_limits(value)
+
+    @pytest.mark.asyncio
+    async def test_get_param_raises_KeyError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(KeyError):
+            await hp.get_param_async("BlaBlaBla")
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize("name, param", HtParams.items())
+    @pytest.mark.asyncio
+    async def test_set_param(
+        self, aiohthp_tcp: AioHtHeatpump, name: str, param: HtParam
+    ) -> None:
+        if param.is_writable:  # type: ignore
+            val = await aiohthp_tcp.get_param_async(name)
+            if isinstance(val, (int, float)):
+                new_val = val + 1 if val + 1 < param.max_val else val - 1  # type: ignore
+                await aiohthp_tcp.set_param_async(name, new_val)
+                assert await aiohthp_tcp.get_param_async(name) == new_val
+
+    @pytest.mark.asyncio
+    async def test_set_param_raises_KeyError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(KeyError):
+            await hp.set_param_async("BlaBlaBla", 123)
+        # assert 0
+
+    @pytest.mark.parametrize(
+        "name, param",
+        [
+            (name, param)
+            for name, param in HtParams.items()
+            if param.data_type in (HtDataTypes.INT, HtDataTypes.FLOAT)
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_set_param_raises_ValueError(
+        self, cmdopt_url: str, name: str, param: HtParam
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        assert param.min_val is not None
+        with pytest.raises(ValueError):
+            await hp.set_param_async(name, param.min_val - 1, ignore_limits=False)
+        assert param.max_val is not None
+        with pytest.raises(ValueError):
+            await hp.set_param_async(name, param.max_val + 1, ignore_limits=False)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_in_error(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        in_error = await aiohthp_tcp.in_error_async
+        assert isinstance(in_error, bool), "'in_error' must be of type bool"
+        assert in_error == await aiohthp_tcp.get_param_async("Stoerung")
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_query(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        values = await aiohthp_tcp.query_async()
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert len(values) == len(HtParams)
+        for name, value in values.items():
+            assert name in HtParams
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize(
+        "names",
+        [
+            random.sample(sorted(HtParams.keys()), cnt)
+            for cnt in range(len(HtParams) + 1)
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_query_with_names(
+        self, aiohthp_tcp: AioHtHeatpump, names: List[str]
+    ) -> None:
+        values = await aiohthp_tcp.query_async(*names)
+        # { "HKR Soll_Raum": 21.0,
+        #   "Stoerung": False,
+        #   "Temp. Aussen": 8.8,
+        #   # ...
+        #   }
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert not names or len(values) == len(set(names))
+        for name, value in values.items():
+            assert name in HtParams
+            assert not names or name in names
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_fast_query(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        values = await aiohthp_tcp.fast_query_async()
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert len(values) == len(
+            [p for p in HtParams.values() if p.dp_type == "MP"]
+        )
+        for name, value in values.items():
+            assert name in HtParams
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize(
+        "names",
+        [
+            random.sample(sorted(HtParams.of_type("MP").keys()), cnt)
+            for cnt in range(len(HtParams.of_type("MP")) + 1)
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_fast_query_with_names(
+        self, aiohthp_tcp: AioHtHeatpump, names: List[str]
+    ) -> None:
+        values = await aiohthp_tcp.fast_query_async(*names)
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert not names or len(values) == len(set(names))
+        for name, value in values.items():
+            assert name in HtParams
+            assert not names or name in names
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    @pytest.mark.asyncio
+    async def test_fast_query_with_names_raises_KeyError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(KeyError):
+            await hp.fast_query_async("BlaBlaBla")
+        # assert 0
+
+    @pytest.mark.parametrize(
+        "names",
+        [
+            random.sample(sorted(HtParams.of_type("SP").keys()), cnt)
+            for cnt in range(1, len(HtParams.of_type("SP")) + 1)
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_fast_query_with_names_raises_ValueError(
+        self, cmdopt_url: str, names: List[str]
+    ) -> None:
+        hp = AioHtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(ValueError):
+            await hp.fast_query_async(*names)
+        # assert 0
+
+    # @pytest.mark.skip(reason="test needs a rework")
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_fast_query_in_several_pieces(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        args = []
+        cmd = ""
+        mp_data_points = [
+            (name, param) for name, param in HtParams.items() if param.dp_type == "MP"
+        ]
+        while len(cmd) < 255 * 2:  # request has do be done in 3 parts
+            name, param = random.choice(mp_data_points)
+            cmd += ",{}".format(param.dp_number)
+            args.append(name)
+        values = await aiohthp_tcp.fast_query_async(*args)
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert not args or len(values) == len(set(args))
+        for name, value in values.items():
+            assert name in HtParams
+            assert not args or name in args
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_get_time_progs(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        time_progs = await aiohthp_tcp.get_time_progs_async()
+        assert isinstance(time_progs, List), "'time_progs' must be of type list"
+        assert len(time_progs) > 0
+        assert all([isinstance(time_prog, TimeProgram) for time_prog in time_progs])
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize("index", range(5))
+    @pytest.mark.asyncio
+    async def test_get_time_prog(self, aiohthp_tcp: AioHtHeatpump, index: int) -> None:
+        time_prog = await aiohthp_tcp.get_time_prog_async(index, with_entries=False)
+        assert isinstance(
+            time_prog, TimeProgram
+        ), "'time_prog' must be of type TimeProgram"
+        time_prog = await aiohthp_tcp.get_time_prog_async(index, with_entries=True)
+        assert isinstance(
+            time_prog, TimeProgram
+        ), "'time_prog' must be of type TimeProgram"
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize("index", [-1, 5])
+    @pytest.mark.asyncio
+    async def test_get_time_prog_raises_IOError(
+        self, aiohthp_tcp: AioHtHeatpump, index: int
+    ) -> None:
+        with pytest.raises(IOError):
+            await aiohthp_tcp.get_time_prog_async(index, with_entries=False)
+        with pytest.raises(IOError):
+            await aiohthp_tcp.get_time_prog_async(index, with_entries=True)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize(
+        "index, day, num",
+        [
+            (index, day, num)
+            for index in range(5)
+            for day in range(7)
+            for num in range(7)
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_get_time_prog_entry(
+        self, aiohthp_tcp: AioHtHeatpump, index: int, day: int, num: int
+    ) -> None:
+        entry = await aiohthp_tcp.get_time_prog_entry_async(index, day, num)
+        assert isinstance(entry, TimeProgEntry), "'entry' must be of type TimeProgEntry"
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.parametrize(
+        "index, day, num",
+        [
+            (5, 0, 0),  # index=5 is invalid
+            (0, 7, 0),  # day=7 is invalid
+            (0, 0, 7),  # num=7 is invalid
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_get_time_prog_entry_raises_IOError(
+        self, aiohthp_tcp: AioHtHeatpump, index: int, day: int, num: int
+    ) -> None:
+        with pytest.raises(IOError):
+            await aiohthp_tcp.get_time_prog_entry_async(index, day, num)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_set_time_prog_entry(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        entry = await aiohthp_tcp.get_time_prog_entry_async(0, 0, 0)
+        new_entry = TimeProgEntry(state=1 - entry.state, period=entry.period)
+        changed_entry = await aiohthp_tcp.set_time_prog_entry_async(0, 0, 0, new_entry)
+        assert changed_entry.state == new_entry.state
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect_async")
+    @pytest.mark.asyncio
+    async def test_set_time_prog(self, aiohthp_tcp: AioHtHeatpump) -> None:
+        time_prog = await aiohthp_tcp.get_time_prog_async(0)
+        entry = time_prog.entry(0, 0)
+        new_entry = TimeProgEntry(state=1 - entry.state, period=entry.period)  # type: ignore
+        time_prog.set_entry(0, 0, new_entry)
+        changed_time_prog = await aiohthp_tcp.set_time_prog_async(time_prog)
+        assert changed_time_prog.entry(0, 0).state == new_entry.state  # type: ignore
+
+
+@pytest.fixture()
+def reconnect(hthp_tcp: HtHeatpump) -> Generator[None, None, None]:
+    hthp_tcp.reconnect()
+    hthp_tcp.login()
+    yield
+    hthp_tcp.logout()
+
+
+class TestHtHeatpumpTCP:
+    @pytest.mark.run_if_connected
+    def test_open_connection(self, hthp_tcp: HtHeatpump) -> None:
+        assert hthp_tcp.is_open
+        with pytest.raises(IOError):
+            hthp_tcp.open_connection()
+        # assert 0
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            VerifyAction.NONE(),
+            {VerifyAction.NAME},
+            {VerifyAction.NAME, VerifyAction.MIN},
+            {VerifyAction.NAME, VerifyAction.MIN, VerifyAction.MAX},
+            {VerifyAction.NAME, VerifyAction.MIN, VerifyAction.MAX, VerifyAction.VALUE},
+            {VerifyAction.MIN, VerifyAction.MAX, VerifyAction.VALUE},
+            {VerifyAction.MAX, VerifyAction.VALUE},
+            {VerifyAction.VALUE},
+            VerifyAction.ALL(),
+        ],
+    )
+    def test_verify_param_action(
+        self, cmdopt_url: str, action: Set[VerifyAction]
+    ) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        val = hp.verify_param_action
+        assert isinstance(val, set)
+        hp.verify_param_action = action
+        assert hp.verify_param_action == action
+        hp.verify_param_action = val
+        # assert 0
+
+    def test_verify_param_error(self, cmdopt_url: str) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        val = hp.verify_param_error
+        assert isinstance(val, bool)
+        hp.verify_param_error = True
+        assert hp.verify_param_error is True
+        hp.verify_param_error = False
+        assert hp.verify_param_error is False
+        hp.verify_param_error = val
+        # assert 0
+
+    def test_send_request(self, cmdopt_url: str) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(IOError):
+            hp.send_request(r"LIN")
+        # assert 0
+
+    def test_read_response(self, cmdopt_url: str) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(IOError):
+            hp.read_response()
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_serial_number(self, hthp_tcp: HtHeatpump) -> None:
+        rid = hthp_tcp.get_serial_number()
+        assert isinstance(rid, int), "'rid' must be of type int"
+        assert rid > 0
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_version(self, hthp_tcp: HtHeatpump) -> None:
+        version = hthp_tcp.get_version()
+        # ( "3.0.20", 2321 )
+        assert isinstance(version, tuple), "'version' must be of type tuple"
+        assert len(version) == 2
+        ver_str, ver_num = version
+        assert isinstance(ver_str, str), "'ver_str' must be of type str"
+        m = re.match(r"^(\d+).(\d+).(\d+)$", ver_str)
+        assert m is not None, "invalid version string [{!r}]".format(ver_str)
+        assert isinstance(ver_num, int), "'ver_num' must be of type int"
+        assert ver_num > 0
+        hthp_tcp.send_request(r"SP,NR=9")
+        resp = hthp_tcp.read_response()
+        m = re.match(r"^SP,NR=9,.*NAME=([^,]+).*VAL=([^,]+).*$", resp)
+        assert (
+            m is not None
+        ), "invalid response for query of the software version [{!r}]".format(resp)
+        assert ver_str == m.group(1).strip()
+        assert ver_num == int(m.group(2))
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_date_time(self, hthp_tcp: HtHeatpump) -> None:
+        date_time = hthp_tcp.get_date_time()
+        # (datetime.datetime(...), 2)  # 2 = Tuesday
+        assert isinstance(date_time, tuple), "'date_time' must be of type tuple"
+        assert len(date_time) == 2
+        dt, weekday = date_time
+        assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+        assert isinstance(weekday, int), "'weekday' must be of type int"
+        assert weekday in range(1, 8)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_set_date_time(self, hthp_tcp: HtHeatpump) -> None:
+        dt_before, _ = hthp_tcp.get_date_time()
+        dt_set, _ = hthp_tcp.set_date_time()
+        dt_after, _ = hthp_tcp.get_date_time()
+        assert (dt_after - dt_before).total_seconds() > 0
+        assert (dt_after - dt_set).total_seconds() < 2
+        # assert 0
+
+    def test_set_date_time_raises_TypeError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(TypeError):
+            hp.set_date_time(123)  # type: ignore
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_last_fault(self, hthp_tcp: HtHeatpump) -> None:
+        fault = hthp_tcp.get_last_fault()
+        # (29, 20, datetime.datetime(...), "EQ_Spreizung")
+        assert isinstance(fault, tuple), "'fault' must be of type tuple"
+        assert len(fault) == 4
+        index, error, dt, msg = fault
+        assert isinstance(index, int), "'index' must be of type int"
+        assert 0 <= index < hthp_tcp.get_fault_list_size()
+        assert isinstance(error, int), "'error' must be of type int"
+        assert error >= 0
+        assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+        assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_fault_list_size(self, hthp_tcp: HtHeatpump) -> None:
+        size = hthp_tcp.get_fault_list_size()
+        assert isinstance(size, int), "'size' must be of type int"
+        assert size >= 0
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_fault_list(self, hthp_tcp: HtHeatpump) -> None:
+        fault_list = hthp_tcp.get_fault_list()
+        # [ { "index": 29,  # fault list index
+        #     "error": 20,  # error code
+        #     "datetime": datetime.datetime(...),  # date and time of the entry
+        #     "message": "EQ_Spreizung",  # error message
+        #     },
+        #   # ...
+        #   ]
+        assert isinstance(fault_list, list), "'fault_list' must be of type list"
+        assert len(fault_list) == hthp_tcp.get_fault_list_size()
+        for entry in fault_list:
+            assert isinstance(entry, dict), "'entry' must be of type dict"
+            index = entry["index"]
+            assert isinstance(index, int), "'index' must be of type int"
+            assert 0 <= index < hthp_tcp.get_fault_list_size()
+            error = entry["error"]
+            assert isinstance(error, int), "'error' must be of type int"
+            assert error >= 0
+            dt = entry["datetime"]
+            assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+            msg = entry["message"]
+            assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    # @pytest.mark.skip(reason="test needs a rework")
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_fault_list_in_several_pieces(self, hthp_tcp: HtHeatpump) -> None:
+        args = []
+        cmd = ""
+        fault_list_size = hthp_tcp.get_fault_list_size()
+        while len(cmd) < 255 * 2:  # request has do be done in 3 parts
+            item = random.randint(0, fault_list_size - 1)
+            cmd += ",{}".format(item)
+            args.append(item)
+        fault_list = hthp_tcp.get_fault_list(*args)
+        # [ { "index": 29,  # fault list index
+        #     "error": 20,  # error code
+        #     "datetime": datetime.datetime(...),  # date and time of the entry
+        #     "message": "EQ_Spreizung",  # error message
+        #     },
+        #   # ...
+        #   ]
+        assert isinstance(fault_list, list), "'fault_list' must be of type list"
+        assert len(fault_list) == len(args)
+        for entry in fault_list:
+            assert isinstance(entry, dict), "'entry' must be of type dict"
+            index = entry["index"]
+            assert isinstance(index, int), "'index' must be of type int"
+            assert 0 <= index < fault_list_size
+            error = entry["error"]
+            assert isinstance(error, int), "'error' must be of type int"
+            assert error >= 0
+            dt = entry["datetime"]
+            assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+            msg = entry["message"]
+            assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_fault_list_with_index(self, hthp_tcp: HtHeatpump) -> None:
+        size = hthp_tcp.get_fault_list_size()
+        assert isinstance(size, int), "'size' must be of type int"
+        assert size >= 0
+        for i in range(size):
+            fault_list = hthp_tcp.get_fault_list(i)
+            assert isinstance(fault_list, list), "'fault_list' must be of type list"
+            assert len(fault_list) == 1
+            entry = fault_list[0]
+            assert isinstance(entry, dict), "'entry' must be of type dict"
+            index = entry["index"]
+            assert isinstance(index, int), "'index' must be of type int"
+            assert 0 <= index < hthp_tcp.get_fault_list_size()
+            error = entry["error"]
+            assert isinstance(error, int), "'error' must be of type int"
+            assert error >= 0
+            dt = entry["datetime"]
+            assert isinstance(dt, datetime.datetime), "'dt' must be of type datetime"
+            msg = entry["message"]
+            assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_fault_list_with_index_raises_IOError(self, hthp_tcp: HtHeatpump) -> None:
+        with pytest.raises(IOError):
+            hthp_tcp.get_fault_list(-1)
+        with pytest.raises(IOError):
+            hthp_tcp.get_fault_list(hthp_tcp.get_fault_list_size())
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_fault_list_with_indices(self, hthp_tcp: HtHeatpump) -> None:
+        size = hthp_tcp.get_fault_list_size()
+        for cnt in range(size + 1):
+            indices = random.sample(range(size), cnt)
+            fault_list = hthp_tcp.get_fault_list(*indices)
+            assert isinstance(fault_list, list), "'fault_list' must be of type list"
+            assert len(fault_list) == (cnt if cnt > 0 else size)
+            for entry in fault_list:
+                assert isinstance(entry, dict), "'entry' must be of type dict"
+                index = entry["index"]
+                assert isinstance(index, int), "'index' must be of type int"
+                assert 0 <= index < hthp_tcp.get_fault_list_size()
+                error = entry["error"]
+                assert isinstance(error, int), "'error' must be of type int"
+                assert error >= 0
+                dt = entry["datetime"]
+                assert isinstance(
+                    dt, datetime.datetime
+                ), "'dt' must be of type datetime"
+                msg = entry["message"]
+                assert isinstance(msg, str), "'msg' must be of type str"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize("name, param", HtParams.items())
+    def test_get_param(self, hthp_tcp: HtHeatpump, name: str, param: HtParam) -> None:
+        value = hthp_tcp.get_param(name)
+        assert value is not None, "'value' must not be None"
+        assert param.in_limits(value)
+        # assert 0
+
+    def test_get_param_raises_KeyError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(KeyError):
+            hp.get_param("BlaBlaBla")
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize("name, param", HtParams.items())
+    def test_set_param(self, hthp_tcp: HtHeatpump, name: str, param: HtParam) -> None:
+        if param.is_writable:  # type: ignore
+            val = hthp_tcp.get_param(name)
+            if isinstance(val, (int, float)):
+                new_val = val + 1 if val + 1 < param.max_val else val - 1  # type: ignore
+                hthp_tcp.set_param(name, new_val)
+                assert hthp_tcp.get_param(name) == new_val
+        # assert 0
+
+    def test_set_param_raises_KeyError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(KeyError):
+            hp.set_param("BlaBlaBla", 123)
+        # assert 0
+
+    @pytest.mark.parametrize(
+        "name, param",
+        [
+            (name, param)
+            for name, param in HtParams.items()
+            if param.data_type in (HtDataTypes.INT, HtDataTypes.FLOAT)
+        ],
+    )
+    def test_set_param_raises_ValueError(
+        self, cmdopt_url: str, name: str, param: HtParam
+    ) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        assert param.min_val is not None
+        with pytest.raises(ValueError):
+            hp.set_param(name, param.min_val - 1, ignore_limits=False)
+        assert param.max_val is not None
+        with pytest.raises(ValueError):
+            hp.set_param(name, param.max_val + 1, ignore_limits=False)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_in_error(self, hthp_tcp: HtHeatpump) -> None:
+        in_error = hthp_tcp.in_error
+        assert isinstance(in_error, bool), "'in_error' must be of type bool"
+        assert in_error == hthp_tcp.get_param("Stoerung")
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_query(self, hthp_tcp: HtHeatpump) -> None:
+        values = hthp_tcp.query()
+        # { "HKR Soll_Raum": 21.0,
+        #   "Stoerung": False,
+        #   "Temp. Aussen": 8.8,
+        #   # ...
+        #   }
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert len(values) == len(HtParams)
+        for name, value in values.items():
+            assert name in HtParams
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize(
+        "names",
+        [
+            random.sample(sorted(HtParams.keys()), cnt)
+            for cnt in range(len(HtParams) + 1)
+        ],
+    )
+    def test_query_with_names(self, hthp_tcp: HtHeatpump, names: List[str]) -> None:
+        values = hthp_tcp.query(*names)
+        # { "HKR Soll_Raum": 21.0,
+        #   "Stoerung": False,
+        #   "Temp. Aussen": 8.8,
+        #   # ...
+        #   }
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert not names or len(values) == len(set(names))
+        for name, value in values.items():
+            assert name in HtParams
+            assert not names or name in names
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_fast_query(self, hthp_tcp: HtHeatpump) -> None:
+        values = hthp_tcp.fast_query()
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert len(values) == len(HtParams.of_type("MP"))
+        for name, value in values.items():
+            assert name in HtParams
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize(
+        "names",
+        [
+            random.sample(sorted(HtParams.of_type("MP").keys()), cnt)
+            for cnt in range(len(HtParams.of_type("MP")) + 1)
+        ],
+    )
+    def test_fast_query_with_names(self, hthp_tcp: HtHeatpump, names: List[str]) -> None:
+        values = hthp_tcp.fast_query(*names)
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert not names or len(values) == len(set(names))
+        for name, value in values.items():
+            assert name in HtParams
+            assert not names or name in names
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    def test_fast_query_with_names_raises_KeyError(
+        self, cmdopt_url: str
+    ) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(KeyError):
+            hp.fast_query("BlaBlaBla")
+        # assert 0
+
+    @pytest.mark.parametrize(
+        "names",
+        [
+            random.sample(sorted(HtParams.of_type("SP").keys()), cnt)
+            for cnt in range(1, len(HtParams.of_type("SP")) + 1)
+        ],
+    )
+    def test_fast_query_with_names_raises_ValueError(
+        self, cmdopt_url: str, names: List[str]
+    ) -> None:
+        hp = HtHeatpump(url=cmdopt_url or "tcp://127.0.0.1:1234")
+        with pytest.raises(ValueError):
+            hp.fast_query(*names)
+        # assert 0
+
+    # @pytest.mark.skip(reason="test needs a rework")
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_fast_query_in_several_pieces(self, hthp_tcp: HtHeatpump) -> None:
+        args = []
+        cmd = ""
+        mp_data_points = [
+            (name, param) for name, param in HtParams.items() if param.dp_type == "MP"
+        ]
+        while len(cmd) < 255 * 2:  # request has do be done in 3 parts
+            name, param = random.choice(mp_data_points)
+            cmd += ",{}".format(param.dp_number)
+            args.append(name)
+        values = hthp_tcp.fast_query(*args)
+        assert isinstance(values, dict), "'values' must be of type dict"
+        assert not args or len(values) == len(set(args))
+        for name, value in values.items():
+            assert name in HtParams
+            assert not args or name in args
+            assert value is not None
+            assert HtParams[name].in_limits(value)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_get_time_progs(self, hthp_tcp: HtHeatpump) -> None:
+        time_progs = hthp_tcp.get_time_progs()
+        assert isinstance(time_progs, List), "'time_progs' must be of type list"
+        assert len(time_progs) > 0
+        assert all([isinstance(time_prog, TimeProgram) for time_prog in time_progs])
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize(
+        "index", range(5)
+    )  # TODO range(5) -> range(len(hthp_tcp.get_time_progs()))
+    def test_get_time_prog(self, hthp_tcp: HtHeatpump, index: int) -> None:
+        time_prog = hthp_tcp.get_time_prog(index, with_entries=False)
+        assert isinstance(
+            time_prog, TimeProgram
+        ), "'time_prog' must be of type TimeProgram"
+        time_prog = hthp_tcp.get_time_prog(index, with_entries=True)
+        assert isinstance(
+            time_prog, TimeProgram
+        ), "'time_prog' must be of type TimeProgram"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize("index", [-1, 5])
+    def test_get_time_prog_raises_IOError(self, hthp_tcp: HtHeatpump, index: int) -> None:
+        with pytest.raises(IOError):
+            hthp_tcp.get_time_prog(index, with_entries=False)
+        with pytest.raises(IOError):
+            hthp_tcp.get_time_prog(index, with_entries=True)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize(
+        "index, day, num",
+        [  # for ALL time program entries
+            (index, day, num)
+            for index in range(5)
+            for day in range(7)
+            for num in range(7)
+        ],
+    )
+    def test_get_time_prog_entry(
+        self, hthp_tcp: HtHeatpump, index: int, day: int, num: int
+    ) -> None:
+        entry = hthp_tcp.get_time_prog_entry(index, day, num)
+        assert isinstance(entry, TimeProgEntry), "'entry' must be of type TimeProgEntry"
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    @pytest.mark.parametrize(
+        "index, day, num",
+        [
+            (5, 0, 0),  # index=5 is invalid
+            (0, 7, 0),  # day=7 is invalid
+            (0, 0, 7),  # num=7 is invalid
+        ],
+    )
+    def test_get_time_prog_entry_raises_IOError(
+        self, hthp_tcp: HtHeatpump, index: int, day: int, num: int
+    ) -> None:
+        with pytest.raises(IOError):
+            hthp_tcp.get_time_prog_entry(index, day, num)
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_set_time_prog_entry(self, hthp_tcp: HtHeatpump) -> None:
+        entry = hthp_tcp.get_time_prog_entry(0, 0, 0)
+        new_entry = TimeProgEntry(
+            state=1 - entry.state,
+            period=entry.period
+        )
+        changed_entry = hthp_tcp.set_time_prog_entry(0, 0, 0, new_entry)
+        assert changed_entry.state == new_entry.state
+        # assert 0
+
+    @pytest.mark.run_if_connected
+    @pytest.mark.usefixtures("reconnect")
+    def test_set_time_prog(self, hthp_tcp: HtHeatpump) -> None:
+        time_prog = hthp_tcp.get_time_prog(0)
+        entry = time_prog.entry(0, 0)
+        new_entry = TimeProgEntry(
+            state=1 - entry.state,  # type: ignore
+            period=entry.period  # type: ignore
+        )
+        time_prog.set_entry(0, 0, new_entry)
+        changed_time_prog = hthp_tcp.set_time_prog(time_prog)
+        assert changed_time_prog.entry(0, 0).state == new_entry.state  # type: ignore
+        # assert 0
+
+
+@pytest.fixture(scope="class")
+def aiohthp_tcp(
+    cmdopt_url: str,
+) -> Generator[AioHtHeatpump, None, None]:
+    ht_hp = AioHtHeatpump(url=cmdopt_url)
+    try:
+        ht_hp.open_connection()
+        yield ht_hp  # provide the heat pump instance
+    finally:
+        ht_hp.close_connection()


### PR DESCRIPTION
Add TCP connection support in both HtHeatpump and AioHtHeatpump clients, starting from the original socket support by dstrigl:
- Upgraded command-line utility scripts to support TCP URLs.
- Added comprehensive tests, including a dedicated suite for TCP socket operations.
- Fixed connection status checks and optimized async timeout reading loops.

AI-aided.